### PR TITLE
Add warning message when global and workspace TLC options set

### DIFF
--- a/src/tla2tools.ts
+++ b/src/tla2tools.ts
@@ -310,12 +310,16 @@ export async function getTlcOptions(showPrompt: boolean): Promise<string[] | und
 
     if (!supressConfigWarnings && allConfigs?.workspaceValue && allConfigs?.globalValue) {
         vscode.window
-            .showWarningMessage("Both workspace and global configurations found for TLC options. Only the workspace configuration will be used.", "ok", "hide warnings")
+            .showWarningMessage(
+                'Both workspace and global configurations found for TLC options. Only the workspace configuration '
+                    + 'will be used.',
+                'ok',
+                'hide warnings')
             .then(selection => {
-                if (selection == "hide warnings") {
+                if (selection === 'hide warnings') {
                     supressConfigWarnings = true;
                 }
-            })
+            });
 
     }
 

--- a/src/tla2tools.ts
+++ b/src/tla2tools.ts
@@ -8,6 +8,9 @@ import { JavaVersionParser } from './parsers/javaVersion';
 import { ShareOption, CFG_TLC_STATISTICS_TYPE } from './commands/tlcStatisticsCfg';
 import { ToolOutputChannel } from './outputChannels';
 
+// CFG_EXTENSION can be used to fetch all the settings for this extension
+const CFG_EXTENSION = '@ext:alygin.vscode-tlaplus';
+
 const CFG_JAVA_HOME = 'tlaplus.java.home';
 const CFG_JAVA_OPTIONS = 'tlaplus.java.options';
 const CFG_TLC_OPTIONS = 'tlaplus.tlc.modelChecker.options';
@@ -296,10 +299,13 @@ function getConfigOptions(cfgName: string, defaultValue: string = ''): string[] 
                 `Both workspace and global configurations found for ${cfgName}. Only the workspace configuration `
                     + 'will be used.',
                 'ok',
-                'hide warnings')
+                'hide warnings',
+                'open settings')
             .then(selection => {
                 if (selection === 'hide warnings') {
                     supressConfigWarnings = true;
+                } else if (selection === 'open settings') {
+                    vscode.commands.executeCommand('workbench.action.openSettings', CFG_EXTENSION);
                 }
             });
     }


### PR DESCRIPTION
Adds on to #207 by adding a warning message (that can be silenced) informing users when they have both global and workspace settings for TLC options. In this case the workspace settings will take precedence. An example warning message is shown below.

![image](https://user-images.githubusercontent.com/6043161/115095526-81096a80-9ed6-11eb-8a35-005680f703ba.png)

This PR addresses the following concern: 
> the extension behavior will be confusing in the following scenario:
>
> - The user runs a model check, provides some options.
> - The user goes to global settings and changes the default options for TLC.
> - The user runs a model check, and the extensions shows the prompt with the same options he or she provided on the step 1, with no respect to the new global settings.

