### PR TITLE
Fix tree item text color

### DIFF
--- a/src/webview/checkResultView/tree/tree-item.styles.ts
+++ b/src/webview/checkResultView/tree/tree-item.styles.ts
@@ -19,12 +19,16 @@ export const treeItemStyles: FoundationElementTemplate<ElementStyles, TreeItemOp
         css`
             ${fastTreeItemStyles(context, definition)}
 
-            :host, .positioning-region, .expand-collapse-button {
+            :host,
+            .positioning-region,
+            .expand-collapse-button {
                 background: transparent;
                 color: var(--vscode-foreground);
             }
 
-            :host([selected]) .positioning-region, :host([selected])::after {
+            :host(:not([disabled])) .positioning-region,
+            :host([selected]) .positioning-region,
+            :host([selected])::after {
                 background: transparent;
                 color: var(--vscode-foreground);
             }


### PR DESCRIPTION
Fixes tree item text color by doing one more override in the custom tree item styles

Reference: https://github.com/tlaplus/vscode-tlaplus/pull/289#issuecomment-1614838191