### PR TITLE
Fix position of the opened window when checking model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,15 @@
                 "vscode": "^1.57.0"
             }
         },
+        "node_modules/@aashutoshrathi/word-wrap": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/@esbuild/android-arm": {
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
@@ -2510,17 +2519,17 @@
             }
         },
         "node_modules/optionator": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+            "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
             "dev": true,
             "dependencies": {
+                "@aashutoshrathi/word-wrap": "^1.2.3",
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0",
-                "word-wrap": "^1.2.3"
+                "type-check": "^0.4.0"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -2846,9 +2855,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.3.8",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -3152,15 +3161,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/workerpool": {

--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -9,7 +9,6 @@ import { ModelCheckResult, ModelCheckResultSource, SpecFiles } from '../model/ch
 import { ToolOutputChannel } from '../outputChannels';
 import { saveStreamToFile } from '../outputSaver';
 import {
-    revealEmptyCheckResultView,
     revealLastCheckResultView,
     updateCheckResultView
 } from '../panels/checkResultView';
@@ -193,7 +192,7 @@ export async function doCheckModel(
         });
         if (showCheckResultView) {
             attachFileSaver(specFiles.tlaFilePath, checkProcess);
-            revealEmptyCheckResultView(ModelCheckResultSource.Process, extContext);
+            revealLastCheckResultView(extContext);
         }
         const resultHolder = new CheckResultHolder();
         const checkResultCallback = (checkResult: ModelCheckResult) => {

--- a/src/commands/visualizeOutput.ts
+++ b/src/commands/visualizeOutput.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import { PassThrough } from 'stream';
 import * as vscode from 'vscode';
 import { ModelCheckResultSource } from '../model/check';
-import { revealEmptyCheckResultView, updateCheckResultView } from '../panels/checkResultView';
+import { revealLastCheckResultView, updateCheckResultView } from '../panels/checkResultView';
 import { TlcModelCheckerStdoutParser } from '../parsers/tlc';
 
 export const CMD_VISUALIZE_TLC_OUTPUT = 'tlaplus.out.visualize';
@@ -34,7 +34,7 @@ export function visualizeTlcOutput(extContext: vscode.ExtensionContext): void {
 function showOutput(buffer: Buffer, extContext: vscode.ExtensionContext) {
     const stream = new PassThrough();
     stream.end(buffer);
-    revealEmptyCheckResultView(ModelCheckResultSource.OutFile, extContext);
+    revealLastCheckResultView(extContext);
     const parser = new TlcModelCheckerStdoutParser(
         ModelCheckResultSource.OutFile, stream, undefined, false, updateCheckResultView);
     parser.readAll();

--- a/src/panels/checkResultView.ts
+++ b/src/panels/checkResultView.ts
@@ -9,7 +9,7 @@ export function updateCheckResultView(checkResult: ModelCheckResult): void {
     CheckResultViewPanel.updateCheckResult(checkResult);
 }
 
-export function revealEmptyCheckResultView(_source: ModelCheckResultSource, extContext: vscode.ExtensionContext): void {
+export function revealEmptyCheckResultView(extContext: vscode.ExtensionContext): void {
     CheckResultViewPanel.renderEmpty(extContext.extensionUri);
 }
 

--- a/src/webview/checkResultView/statsSection/coverageStats.tsx
+++ b/src/webview/checkResultView/statsSection/coverageStats.tsx
@@ -5,10 +5,6 @@ import { CodeRangeLink, DataGridCellDefault, DataGridCellHeader } from '../commo
 
 interface CoverageStatsI {stats: CoverageItem[]}
 export const CoverageStats = React.memo(({stats}: CoverageStatsI) => {
-    if (stats.length === 0) {
-        return (null);
-    }
-
     const tooltip = (stat: CoverageItem) =>
         stat.total !== 0 ? '' : 'This action has never been used to compute successor states';
 

--- a/src/webview/checkResultView/statsSection/index.tsx
+++ b/src/webview/checkResultView/statsSection/index.tsx
@@ -13,7 +13,7 @@ export const StatsSection = React.memo(({checkResult}: StatsSectionI) => {
         <section>
             <VSCodePanels>
                 <StatesStats stats={checkResult.initialStatesStat}/>
-                <CoverageStats stats={checkResult.coverageStat}/>
+                {checkResult.coverageStat.length > 0 && <CoverageStats stats={checkResult.coverageStat}/>}
             </VSCodePanels>
             <EmptyLine/>
             <VSCodeDivider/>


### PR DESCRIPTION
Hi, this MR fixes the opening of the webview in wrong window when clicking the check again button.

The previous behaviour was that the check model window would be closed and a new one is created "beside" the active window. The new behaviour is that reuses the opened window, if there is any.

Also updated dependencies with vulnerabilities and cleaned up a bit the code of the webview to avoid a visual bug when reusing the window, namely the following one where the underscore of the active tab is in the wrong place:
 
![image](https://github.com/tlaplus/vscode-tlaplus/assets/21228942/21cb4a1e-4046-421f-a3bb-01defd9e6481)


Fixes #295