### PR TITLE
Fix render of empty webview on new model check

### DIFF
--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -9,6 +9,7 @@ import { ModelCheckResult, ModelCheckResultSource, SpecFiles } from '../model/ch
 import { ToolOutputChannel } from '../outputChannels';
 import { saveStreamToFile } from '../outputSaver';
 import {
+    revealEmptyCheckResultView,
     revealLastCheckResultView,
     updateCheckResultView
 } from '../panels/checkResultView';
@@ -192,7 +193,7 @@ export async function doCheckModel(
         });
         if (showCheckResultView) {
             attachFileSaver(specFiles.tlaFilePath, checkProcess);
-            revealLastCheckResultView(extContext);
+            revealEmptyCheckResultView(extContext);
         }
         const resultHolder = new CheckResultHolder();
         const checkResultCallback = (checkResult: ModelCheckResult) => {

--- a/src/commands/visualizeOutput.ts
+++ b/src/commands/visualizeOutput.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import { PassThrough } from 'stream';
 import * as vscode from 'vscode';
 import { ModelCheckResultSource } from '../model/check';
-import { revealLastCheckResultView, updateCheckResultView } from '../panels/checkResultView';
+import { revealEmptyCheckResultView, updateCheckResultView } from '../panels/checkResultView';
 import { TlcModelCheckerStdoutParser } from '../parsers/tlc';
 
 export const CMD_VISUALIZE_TLC_OUTPUT = 'tlaplus.out.visualize';
@@ -34,7 +34,7 @@ export function visualizeTlcOutput(extContext: vscode.ExtensionContext): void {
 function showOutput(buffer: Buffer, extContext: vscode.ExtensionContext) {
     const stream = new PassThrough();
     stream.end(buffer);
-    revealLastCheckResultView(extContext);
+    revealEmptyCheckResultView(extContext);
     const parser = new TlcModelCheckerStdoutParser(
         ModelCheckResultSource.OutFile, stream, undefined, false, updateCheckResultView);
     parser.readAll();

--- a/src/panels/checkResultView.ts
+++ b/src/panels/checkResultView.ts
@@ -37,6 +37,7 @@ class CheckResultViewPanel {
             vscode.ViewColumn.Beside,
             {
                 enableScripts: true,
+                retainContextWhenHidden: true,
                 localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'out')]
             }
         );
@@ -64,23 +65,25 @@ class CheckResultViewPanel {
     }
 
     public static renderEmpty(extensionUri: vscode.Uri) {
-        if (CheckResultViewPanel.currentPanel) {
-            CheckResultViewPanel.currentPanel.dispose();
+        if (!CheckResultViewPanel.currentPanel) {
+            CheckResultViewPanel.currentPanel = new CheckResultViewPanel(extensionUri);
         }
 
-        CheckResultViewPanel.currentPanel = new CheckResultViewPanel(extensionUri);
+        this.updateCheckResult(ModelCheckResult.createEmpty(ModelCheckResultSource.Process));
+        CheckResultViewPanel.currentPanel.panel.reveal();
     }
 
     public static renderLastResult(extensionUri: vscode.Uri) {
-        if (CheckResultViewPanel.currentPanel) {
-            CheckResultViewPanel.currentPanel.panel.reveal();
-            return;
+        if (!CheckResultViewPanel.currentPanel) {
+            CheckResultViewPanel.currentPanel = new CheckResultViewPanel(extensionUri);
         }
 
-        CheckResultViewPanel.currentPanel = new CheckResultViewPanel(extensionUri);
-        if (CheckResultViewPanel.lastCheckResult) {
-            CheckResultViewPanel.currentPanel.updateView(CheckResultViewPanel.lastCheckResult);
-        }
+        const lastModelResult = CheckResultViewPanel.lastCheckResult
+            ? CheckResultViewPanel.lastCheckResult
+            : ModelCheckResult.createEmpty(ModelCheckResultSource.Process);
+
+        this.updateCheckResult(lastModelResult);
+        CheckResultViewPanel.currentPanel.panel.reveal();
     }
 
     private updateView(checkResult: ModelCheckResult) {


### PR DESCRIPTION
Render a empty window when checking a new model, and change logic of rendering a empty window to post a empty check model result to a window instead of closing and opening a window.

Added the flag `retainContextWhenHidden` to the webview so it retains the context in the background and its not re rendered when moved or switching tabs. (https://code.visualstudio.com/api/extension-guides/webview#retaincontextwhenhidden)

REF: https://github.com/tlaplus/vscode-tlaplus/issues/295#issuecomment-1641549971