### PR TITLE
Fix devcontainer JRE installation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.hub.docker.com/pandoc/latex:3-ubuntu AS latex
 
-FROM mcr.microsoft.com/devcontainers/typescript-node:18
+FROM mcr.microsoft.com/devcontainers/typescript-node:18-bullseye
 
 RUN apt update \
     && export DEBIAN_FRONTEND=noninteractive \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,6 @@ This project has a devcontainer (https://code.visualstudio.com/docs/devcontainer
 
 When running the extension in debug mode you only have access to the project folder. If you wish to mount more folders you can add them in the mounts section of the [devcontainer.json](.devcontainer/devcontainer.json) file.
 
-If you are running on an arm machine add "-bullseye" to the [Dockerfile](.devcontainer/Dockerfile): https://github.com/devcontainers/images/tree/main/src/typescript-node.
-
 ## Test from VS Code
 
 To run unit tests from VS Code:


### PR DESCRIPTION
Pin OS version to bullseye as the latest one (bookworm) is missing jre 11 in the package repos.

References:
* https://github.com/tlaplus/vscode-tlaplus/pull/280#issuecomment-1646582591
* https://github.com/devcontainers/images/blob/main/src/typescript-node/README.md