### PR TITLE
Highlight variable change type

### DIFF
--- a/src/webview/checkResultView/errorTraceSection/errorTraceVariable.tsx
+++ b/src/webview/checkResultView/errorTraceSection/errorTraceVariable.tsx
@@ -24,26 +24,26 @@ export const ErrorTraceVariable = React.memo(({value, stateId, settings}: ErrorT
         vscode.showInfoMessage('Value has been copied to clipboard');
     };
 
-    const varDeletedClass = value.changeType === 'D' ? 'value-deleted' : '';
+    const changeTypeClass = 'value-'+value.changeType;
 
     return (
         <VSCodeTreeItem expanded={expanded} onExpandedChanged={handleExpanded}>
             <div className="var-block">
-                <div className="var-name">
-                    <span className={varDeletedClass}> {value.key} </span>
+                <div className="var-name" title={changeHints[value.changeType]}>
+                    <span className={changeTypeClass}> {value.key} </span>
 
                     {value.items &&
                         <span className="var-size" title="Size of the collection"> ({value.items.length}) </span>}
 
                     {value.changeType !== 'N' &&
-                        <span
-                            title={changeHints[value.changeType]}
-                            className={`change-marker change-marker-${value.changeType}`}>
+                        <span className={`change-marker change-marker-${value.changeType}`}>
                             {value.changeType}
                         </span>}
                 </div>
 
-                <div className={'var-value ' + varDeletedClass}> {value.str} </div>
+                <div className={'var-value ' + changeTypeClass} title={changeHints[value.changeType]}>
+                    {value.str}
+                </div>
 
                 <div className="var-menu">
                     <span

--- a/src/webview/checkResultView/errorTraceSection/index.css
+++ b/src/webview/checkResultView/errorTraceSection/index.css
@@ -96,7 +96,15 @@
     color: var(--vscode-gitDecoration-deletedResourceForeground);
 }
 
-.value-deleted {
+.value-D {
     opacity: 0.6;
     text-decoration: line-through;
+}
+
+.value-A {
+    text-decoration: underline var(--vscode-gitDecoration-addedResourceForeground);
+}
+
+.value-M {
+    text-decoration: underline dotted var(--vscode-gitDecoration-modifiedResourceForeground);
 }


### PR DESCRIPTION
Added underline to show change type of variables in error trace, see example below:

<img width="577" alt="image" src="https://github.com/tlaplus/vscode-tlaplus/assets/21228942/b8003c3c-4f18-4b60-97ec-9cb3206908e6">

<img width="575" alt="image" src="https://github.com/tlaplus/vscode-tlaplus/assets/21228942/9a1e79ba-c956-4a91-89e0-2050b2942a59">


Reference: https://github.com/tlaplus/vscode-tlaplus/issues/250#issuecomment-1710972668