### PR TITLE
Remove keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,12 +210,6 @@
                 "category": "TLA+"
             }
         ],
-        "keybindings": [
-            {
-                "command": "tlaplus.tlaps.check-step",
-                "key": "ctrl+g ctrl+g"
-            }
-        ],
         "snippets": [
             {
                 "language": "tlaplus",


### PR DESCRIPTION
No existing commands include default keybindings, so I believe the new features in #307 should not have added keybindings.

This particular keybinding conflicts with existing system bindings, so removing this entirely will resolve #308.