### PR TITLE
Module search paths can be shared between tools.

### DIFF
--- a/package.json
+++ b/package.json
@@ -401,6 +401,12 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Mark proof step states using whole line."
+                },
+                "tlaplus.moduleSearchPaths": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Paths to look for TLA+ modules.",
+                    "default": []
                 }
             }
         },
@@ -489,6 +495,11 @@
                     "id": "tlaplus.current-proof-step",
                     "name": "Current Proof Step",
                     "type": "webview"
+                },
+                {
+                    "id": "tlaplus.module-search-paths",
+                    "name": "Module Search Paths",
+                    "type": "tree"
                 }
             ]
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,8 @@ import { TlaDocumentInfos } from './model/documentInfo';
 import { syncTlcStatisticsSetting, listenTlcStatConfigurationChanges } from './commands/tlcStatisticsCfg';
 import { TlapsClient } from './tlaps';
 import { CurrentProofStepWebviewViewProvider } from './panels/currentProofStepWebviewViewProvider';
+import { moduleSearchPaths } from './paths';
+import { ModuleSearchPathsTreeDataProvider } from './panels/moduleSearchPathsTreeDataProvider';
 
 const TLAPLUS_FILE_SELECTOR: vscode.DocumentSelector = { scheme: 'file', language: LANG_TLAPLUS };
 const TLAPLUS_CFG_FILE_SELECTOR: vscode.DocumentSelector = { scheme: 'file', language: LANG_TLAPLUS_CFG };
@@ -44,6 +46,8 @@ let tlapsClient: TlapsClient | undefined;
  * Extension entry point.
  */
 export function activate(context: vscode.ExtensionContext): void {
+    moduleSearchPaths.setup(context);
+
     const currentProofStepWebviewViewProvider = new CurrentProofStepWebviewViewProvider(context.extensionUri);
     diagnostic = vscode.languages.createDiagnosticCollection(LANG_TLAPLUS);
     context.subscriptions.push(
@@ -167,6 +171,10 @@ export function activate(context: vscode.ExtensionContext): void {
         vscode.window.registerWebviewViewProvider(
             CurrentProofStepWebviewViewProvider.viewType,
             currentProofStepWebviewViewProvider,
+        ),
+        vscode.window.registerTreeDataProvider(
+            ModuleSearchPathsTreeDataProvider.viewType,
+            new ModuleSearchPathsTreeDataProvider(context)
         )
     );
     tlapsClient = new TlapsClient(context, details => {

--- a/src/model/paths.ts
+++ b/src/model/paths.ts
@@ -1,0 +1,7 @@
+export interface InitRequestInItializationOptions {
+    moduleSearchPaths: string[] | null | undefined
+}
+
+export interface InitResponseCapabilitiesExperimental {
+    moduleSearchPaths: string[] | null | undefined
+}

--- a/src/panels/moduleSearchPathsTreeDataProvider.ts
+++ b/src/panels/moduleSearchPathsTreeDataProvider.ts
@@ -1,0 +1,60 @@
+import * as vscode from 'vscode';
+import { moduleSearchPaths, ModuleSearchPathSource } from '../paths';
+
+const sourceIcon = new vscode.ThemeIcon('folder-library');
+const zipDirIcon = new vscode.ThemeIcon('file-zip');
+const folderIcon = new vscode.ThemeIcon('folder');
+
+class mspSource extends vscode.TreeItem {
+    level = 'source';
+    constructor(
+        public source: ModuleSearchPathSource
+    ) {
+        super(source.description, vscode.TreeItemCollapsibleState.Expanded);
+    }
+    iconPath = sourceIcon;
+}
+
+class mspPath extends vscode.TreeItem {
+    level = 'path';
+    constructor(
+        path: string
+    ) {
+        super(path, vscode.TreeItemCollapsibleState.None);
+        this.iconPath = path.startsWith('jar://') ? zipDirIcon : folderIcon;
+    }
+}
+
+type msp = mspSource | mspPath
+
+export class ModuleSearchPathsTreeDataProvider implements vscode.TreeDataProvider<msp> {
+    static readonly viewType = 'tlaplus.module-search-paths';
+    private _onDidChangeTreeData = new vscode.EventEmitter<msp | msp[] | undefined | null | void>();
+    readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+    constructor(
+        private context: vscode.ExtensionContext
+    ) {
+        context.subscriptions.push(moduleSearchPaths.updates(_ => {
+            this._onDidChangeTreeData.fire();
+        }));
+    }
+
+    getChildren(element?: msp): Thenable<msp[]> {
+        if (!element) {
+            return Promise.resolve(
+                moduleSearchPaths.getSources().map(s => new mspSource(s))
+            );
+        }
+        if (element.level === 'source') {
+            return Promise.resolve(
+                moduleSearchPaths.getSourcePaths((element as mspSource).source.name).map(p => new mspPath(p))
+            );
+        }
+        return Promise.resolve([]);
+    }
+
+    getTreeItem(element: msp): vscode.TreeItem {
+        return element;
+    }
+}

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,85 @@
+import * as vscode from 'vscode';
+import * as tla2tools from './tla2tools';
+
+export const TLAPS = 'TLAPS';
+export const TLC = 'TLC';
+export const CFG = 'CFG';
+
+export interface ModuleSearchPathSource {
+    name: string;
+    description: string;
+}
+
+class ModuleSearchPaths {
+    private priority = [CFG, TLC, TLAPS];
+    private sources: { [source: string]: string } = {};
+    private paths: { [source: string]: string[] } = {};
+
+    private _updates = new vscode.EventEmitter<void>();
+    readonly updates = this._updates.event;
+
+    public setup(context: vscode.ExtensionContext) {
+        this.setSourcePaths(TLC, 'TLC Model Checker', tla2tools.moduleSearchPaths());
+        const fromCfg = () => {
+            const config = vscode.workspace.getConfiguration();
+            const cfgPaths = config.get<string[]>('tlaplus.moduleSearchPaths');
+            this.setSourcePaths(CFG, 'Configured Paths', cfgPaths ? cfgPaths : []);
+        };
+        context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((e: vscode.ConfigurationChangeEvent) => {
+            if (e.affectsConfiguration('tlaplus.moduleSearchPaths')) {
+                fromCfg();
+                vscode.commands.executeCommand(
+                    'tlaplus.tlaps.moduleSearchPaths.updated.lsp',
+                    ...this.getOtherPaths(TLAPS)
+                );
+            }
+        }));
+        fromCfg();
+    }
+
+    // Order first by the defined priority, then all the remaining alphabetically, just to be predictable.
+    private sourceOrder(): string[] {
+        const sourceNames = Object.keys(this.sources);
+        const ordered: string[] = [];
+        this.priority.forEach(sn => {
+            if (sourceNames.includes(sn)) {
+                ordered.push(sn);
+            }
+        });
+        const other = sourceNames.filter(sn => !this.priority.includes(sn));
+        other.sort();
+        ordered.push(...other);
+        return ordered;
+    }
+
+    public getSources(): ModuleSearchPathSource[] {
+        return this.sourceOrder().map<ModuleSearchPathSource>(sn => {
+            return {
+                name: sn,
+                description: this.sources[sn]
+            };
+        });
+    }
+
+    public getSourcePaths(source: string): string[] {
+        return this.paths[source];
+    }
+
+    // Return all the paths except the specified source.
+    public getOtherPaths(source: string): string[] {
+        return this.sourceOrder().reduce<string[]>((acc, s) => {
+            if (s !== source) {
+                acc.push(... this.paths[s]);
+            }
+            return acc;
+        }, []);
+    }
+
+    public setSourcePaths(source: string, description: string, paths: string[]) {
+        this.sources[source] = description;
+        this.paths[source] = paths;
+        this._updates.fire();
+    }
+}
+
+export const moduleSearchPaths = new ModuleSearchPaths();

--- a/src/tla2tools.ts
+++ b/src/tla2tools.ts
@@ -25,10 +25,12 @@ const NO_ERROR = 0;
 const MIN_TLA_ERROR = 10;           // Exit codes not related to tooling start from this number
 const LOWEST_JAVA_VERSION = 8;
 const DEFAULT_GC_OPTION = '-XX:+UseParallelGC';
+const TLA_CMODS_LIB_NAME = 'CommunityModules-deps.jar';
 const TLA_TOOLS_LIB_NAME = 'tla2tools.jar';
 const TLA_TOOLS_LIB_NAME_END_UNIX = '/' + TLA_TOOLS_LIB_NAME;
 const TLA_TOOLS_LIB_NAME_END_WIN = '\\' + TLA_TOOLS_LIB_NAME;
 const toolsJarPath = path.resolve(__dirname, '../tools/' + TLA_TOOLS_LIB_NAME);
+const cmodsJarPath = path.resolve(__dirname, '../tools/' + TLA_CMODS_LIB_NAME);
 const javaCmd = 'java' + (process.platform === 'win32' ? '.exe' : '');
 const javaVersionChannel = new ToolOutputChannel('TLA+ Java version');
 const TLA_TOOLS_STANDARD_MODULES = '/tla2sany/StandardModules';
@@ -158,7 +160,8 @@ async function runTool(
 
 export function moduleSearchPaths(): string[] {
     return [
-        'jar:file:' + toolsJarPath + '!' + TLA_TOOLS_STANDARD_MODULES
+        'jar:file:' + toolsJarPath + '!' + TLA_TOOLS_STANDARD_MODULES,
+        'jar:file:' + cmodsJarPath + '!' + '/'
     ];
 }
 


### PR DESCRIPTION
This is an attempt to resolve https://github.com/tlaplus/vscode-tlaplus/issues/323
The paths are passed to SANY and TLC. TLAPS gets the paths as well.
For visibility, I added a tree view to see the paths and their origins.
`jar:` paths are ignored for now but should be supported later.

![image](https://github.com/tlaplus/vscode-tlaplus/assets/442726/0025d95f-bca6-4999-9a13-b7af13422ed4)
