### PR TITLE
fix: file path parsing in sany output

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,6 @@
     ],
     "main": "./out/main.js",
     "browser": "./out/main.browser.js",
-    "files": [
-        "resources",
-        "tools"
-    ],
     "contributes": {
         "terminal": {
             "profiles": [

--- a/src/parsers/sany.ts
+++ b/src/parsers/sany.ts
@@ -248,10 +248,10 @@ export class SanyStdoutParser extends ProcessOutputHandler<SanyData> {
     }
 
     private tryParseModulePath(line: string) {
-        const rxJarPath = /^(.*)(?: \(.*\))$/g;
-        const jarPathMatches = rxJarPath.exec(line);
-        const modPath = jarPathMatches ? jarPathMatches[1] : line;
-        this.rememberParsedModule(modPath);
+        const rxModulePath = /^(.*)(?: \(.*\))$/g;
+        const moldulePathMatches = rxModulePath.exec(line);
+        const modulePath = moldulePathMatches ? moldulePathMatches[1] : line;
+        this.rememberParsedModule(modulePath);
     }
 
     private appendErrMessage(line: string) {

--- a/src/parsers/sany.ts
+++ b/src/parsers/sany.ts
@@ -248,7 +248,7 @@ export class SanyStdoutParser extends ProcessOutputHandler<SanyData> {
     }
 
     private tryParseModulePath(line: string) {
-        const rxJarPath = /^(.*)(?: \(jar:file:.*\))$/g;
+        const rxJarPath = /^(.*)(?: \(.*\))$/g;
         const jarPathMatches = rxJarPath.exec(line);
         const modPath = jarPathMatches ? jarPathMatches[1] : line;
         this.rememberParsedModule(modPath);

--- a/src/webview/checkResultView/common.tsx
+++ b/src/webview/checkResultView/common.tsx
@@ -7,13 +7,15 @@ export const EmptyLine = () => <div style={{marginTop: '1em'}}/>;
 
 interface CodeRangeLinkI {line: string, filepath: string | undefined, range: Range}
 export const CodeRangeLink = React.memo(({line, filepath, range}: CodeRangeLinkI) => (
-    (!filepath || !range) ? (null) : <CodePositionLink line={line} filepath={filepath} position={range[0]}/>
+    (!filepath || !range)
+        ? <>{line}</>
+        : <CodePositionLink line={line} filepath={filepath} position={range[0]}/>
 ));
 
 interface CodePositionLinkI {line: string, filepath: string | undefined, position: Position | undefined}
 export const CodePositionLink = React.memo(({line, filepath, position}: CodePositionLinkI) => {
     if (!filepath || !position) {
-        return (null);
+        return (<>{line}</>);
     }
 
     const location = {'line': position.line, 'character': position.character};


### PR DESCRIPTION
# Changes
* Fixes file path parsing in sany output
    * In windows line is as follows: `Parsing file C:\Users\Afonso\CPlusCal.tla (file:/c:/Users/Afonso/CPlusCal.tla)`
    * In Linux line is as follows: `Parsing file /workspaces/folder/CPlusCal.tla`
    * Custom sany parser expects line to end with `(jar:file:.*)` or nothing, changed to expect `(.*)` or nothing
* In case filepath or changes range are null show action name instead of null
* Remove files property from package json as that information is present in `.vscodeignore` file and having both causes vsce to not work with following error
    *  `ERROR  Both a .vscodeignore file and a "files" property in package.json were found. VSCE does not support combining both strategies. Either remove the .vscodeignore file or the "files" property in package.json.`

Fixes #329 