### PR TITLE
Display infobox when .cfg is missing

### DIFF
--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -50,7 +50,7 @@ export async function checkModel(
         return;
     }
 
-    const specFiles = await getSpecFiles(uri, false);
+    const specFiles = await getSpecFiles(uri);
     if (!specFiles) {
         return;
     }
@@ -231,11 +231,11 @@ function attachFileSaver(tlaFilePath: string, proc: ChildProcess) {
 /**
  * Finds all files that needed to run model check.
  */
-export async function getSpecFiles(fileUri: vscode.Uri, warn = true, prefix = 'MC'): Promise<SpecFiles | undefined> {
+export async function getSpecFiles(fileUri: vscode.Uri, prefix = 'MC'): Promise<SpecFiles | undefined> {
     let specFiles;
 
     // a) Check the given input if it exists.
-    specFiles = await checkSpecFiles(fileUri, false);
+    specFiles = await checkSpecFiles(fileUri);
     if (specFiles) {
         return specFiles;
     }
@@ -254,27 +254,27 @@ export async function getSpecFiles(fileUri: vscode.Uri, warn = true, prefix = 'M
         specFiles = new SpecFiles(filePath, replaceExtension(filePath, 'cfg'));
         // Here, we make sure that the .cfg *and* the .tla exist.
         let canRun = true;
-        canRun = await checkModelExists(specFiles.cfgFilePath, warn);
-        canRun = canRun && await checkModuleExists(specFiles.tlaFilePath, warn);
+        canRun = await checkModelExists(specFiles.cfgFilePath);
+        canRun = canRun && await checkModuleExists(specFiles.tlaFilePath);
         if (canRun) {
             return specFiles;
         }
     }
     // c) Deliberately trigger the warning dialog by checking the given input again
     // knowing that it doesn't exist.
-    return await checkSpecFiles(fileUri, warn);
+    return await checkSpecFiles(fileUri);
 }
 
-async function checkSpecFiles(fileUri: vscode.Uri, warn = true): Promise<SpecFiles | undefined> {
+async function checkSpecFiles(fileUri: vscode.Uri): Promise<SpecFiles | undefined> {
     const filePath = fileUri.fsPath;
     let specFiles;
     let canRun = true;
     if (filePath.endsWith('.cfg')) {
         specFiles = new SpecFiles(replaceExtension(filePath, 'tla'), filePath);
-        canRun = await checkModuleExists(specFiles.tlaFilePath, warn);
+        canRun = await checkModuleExists(specFiles.tlaFilePath);
     } else if (filePath.endsWith('.tla')) {
         specFiles = new SpecFiles(filePath, replaceExtension(filePath, 'cfg'));
-        canRun = await checkModelExists(specFiles.cfgFilePath, warn);
+        canRun = await checkModelExists(specFiles.cfgFilePath);
     }
     return canRun ? specFiles : undefined;
 }
@@ -288,9 +288,9 @@ async function checkModuleExists(modulePath: string, warn = true): Promise<boole
     return moduleExists;
 }
 
-async function checkModelExists(cfgPath: string, warn = true): Promise<boolean> {
+async function checkModelExists(cfgPath: string): Promise<boolean> {
     const cfgExists = await exists(cfgPath);
-    if (!cfgExists && warn) {
+    if (!cfgExists) {
         showConfigAbsenceWarning(cfgPath);
     }
     return cfgExists;

--- a/src/debugger/debugging.ts
+++ b/src/debugger/debugging.ts
@@ -144,7 +144,7 @@ export async function smokeTestSpec(
 
     const prefixPath = vscode.workspace.getConfiguration().get<string>('tlaplus.smoke.prefix.path', '');
     const prefixName = vscode.workspace.getConfiguration().get<string>('tlaplus.smoke.prefix.name', 'Smoke');
-    const specFiles = await getSpecFiles(targetResource, false, prefixPath + prefixName);
+    const specFiles = await getSpecFiles(targetResource, prefixPath + prefixName);
     if (!specFiles || !specFiles.cfgFileName.startsWith(prefixName)) {
         // Launch the debugger iff there is a Smoke model. specFiles
         // might be an ordinary model, which we don't want to run in TLC


### PR DESCRIPTION
When running command "TLA+: Check model with TLC", if the .cfg file is missing, we don't get a warning or anything. This can be
source of confusion. Removed the warn parameter as it was already defaulting to true. This will lead in more consistent behavior as well.

Solves: #331
Ref: #335 and commit: https://github.com/tlaplus/vscode-tlaplus/commit/2092aeb3e1a006613c92caef668ae87e42a5d293

New behavior when running "TLA+: Check model with TLC":
![image](https://github.com/user-attachments/assets/870d4606-1ae8-4d82-b769-4481c902a857)
