### PR TITLE
Don't generate .cfg file when transpiling pluscal

### DIFF
--- a/src/tla2tools.ts
+++ b/src/tla2tools.ts
@@ -34,6 +34,7 @@ const cmodsJarPath = path.resolve(__dirname, '../tools/' + TLA_CMODS_LIB_NAME);
 const javaCmd = 'java' + (process.platform === 'win32' ? '.exe' : '');
 const javaVersionChannel = new ToolOutputChannel('TLA+ Java version');
 const TLA_TOOLS_STANDARD_MODULES = '/tla2sany/StandardModules';
+const TLA_TOOLS_PLUSCAL_PARAM_SKIP_CFG_CREATION = "-nocfg";
 
 let lastUsedJavaHome: string | undefined;
 let cachedJavaPath: string | undefined;
@@ -243,6 +244,7 @@ export function buildTlcOptions(tlaFilePath: string, cfgFilePath: string, custom
  */
 export function buildPlusCalOptions(tlaFilePath: string, customOptions: string[]): string[] {
     const opts = customOptions.slice(0);
+    opts.push(TLA_TOOLS_PLUSCAL_PARAM_SKIP_CFG_CREATION);
     opts.push(path.basename(tlaFilePath));
     return opts;
 }

--- a/tests/suite/tla2tools.test.ts
+++ b/tests/suite/tla2tools.test.ts
@@ -7,13 +7,13 @@ suite('TLA+ Tools Test Suite', () => {
     test('Builds PlusCal options with no custom settings', () => {
         assert.deepEqual(
             buildPlusCalOptions('/path/to/module.tla', []),
-            ['module.tla']
+            ['-nocfg', 'module.tla']
         );
     });
 
     test('Puts PlusCal custom options before module name', () => {
         assert.deepEqual(
-            buildPlusCalOptions('/path/to/module.tla', ['-lineWidth', '100', '-nocfg']),
+            buildPlusCalOptions('/path/to/module.tla', ['-lineWidth', '100']),
             ['-lineWidth', '100', '-nocfg', 'module.tla']
         );
     });


### PR DESCRIPTION
The .cfg file generation is handled by tlatools, and we can skip the .cfg generation by providing the -nocfg parameter (ref: https://github.com/tlaplus/tlaplus/blob/master/tlatools/org.lamport.tlatools/src/pcal/trans.java#L448).
Solves: #293.