### PR TITLE
Show simulator's progress on the table in the side panel

### DIFF
--- a/src/parsers/tlc.ts
+++ b/src/parsers/tlc.ts
@@ -347,6 +347,7 @@ class ModelCheckResultBuilder {
                 this.workersCount -= 1;
                 break;
             case msg.TLC_PROGRESS_STATS:
+            case msg.TLC_PROGRESS_SIMU:
                 this.parseProgressStats(message.lines);
                 this.status = CheckStatus.SuccessorStatesComputing;
                 break;

--- a/src/parsers/tlcCodes.ts
+++ b/src/parsers/tlcCodes.ts
@@ -223,7 +223,7 @@ export const TLC_COVERAGE_END = registerCode(2202, TlcCodeType.Ignore);
 export const TLC_CHECKPOINT_RECOVER_END_DFID = registerCode(2203, TlcCodeType.Ignore);
 export const TLC_PROGRESS_START_STATS_DFID = registerCode(2205, TlcCodeType.Ignore);
 export const TLC_PROGRESS_STATS_DFID = registerCode(2206, TlcCodeType.Ignore);
-export const TLC_PROGRESS_SIMU = registerCode(2209, TlcCodeType.Ignore);
+export const TLC_PROGRESS_SIMU = registerCode(2209, TlcCodeType.Info);
 export const TLC_FP_COMPLETED = registerCode(2211, TlcCodeType.Ignore);
 
 export const TLC_LIVE_IMPLIED = registerCode(2212, TlcCodeType.Ignore);


### PR DESCRIPTION
Fixes #324.

![image](https://github.com/user-attachments/assets/495323a1-ece9-499a-8112-390df18d6ee6)

I've also opened https://github.com/tlaplus/tlaplus/pull/1016  to print the initial entry on this table. Thankfully the [regex](https://github.com/tlaplus/vscode-tlaplus/blob/master/src/parsers/tlc.ts#L471) is able to handle the slightly different log line produced by the simulator output, so no additional changes were needed. Please let me know if this is the correct expectation for that ticket!
Tested with the spec from that ticket and run with "Check model with tlc" and additional parameters: `-fpmem 0.9 -simulate -checkpoint 10`.