### PR TITLE
Fix broken syntax highlighting after the first submodule

### DIFF
--- a/languages/tlaplus-grammar.json
+++ b/languages/tlaplus-grammar.json
@@ -171,6 +171,9 @@
             },
             "patterns": [
                 {
+                    "include" : "#module"
+                },
+                {
                     "include": "#pluscal"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -507,7 +507,7 @@
         "watch": "npm run compile -- --watch",
         "pretest": "tsc -p ./",
         "test": "node ./out/tests/runTest.js",
-        "test:tlaplus-grammar": "vscode-tmgrammar-test ./tests/suite/languages/tlaplus-grammar-test.tla -g ./languages/tlaplus-grammar.json -g ./languages/pluscal-grammar.json"
+        "test:tlaplus-grammar": "vscode-tmgrammar-test ./tests/suite/languages/tlaplus-grammar-test.tla ./tests/suite/languages/tlaplus-grammar-test-submodule.tla -g ./languages/tlaplus-grammar.json -g ./languages/pluscal-grammar.json"
     },
     "devDependencies": {
         "@types/glob": "^8.1.0",

--- a/src/tla2tools.ts
+++ b/src/tla2tools.ts
@@ -34,7 +34,7 @@ const cmodsJarPath = path.resolve(__dirname, '../tools/' + TLA_CMODS_LIB_NAME);
 const javaCmd = 'java' + (process.platform === 'win32' ? '.exe' : '');
 const javaVersionChannel = new ToolOutputChannel('TLA+ Java version');
 const TLA_TOOLS_STANDARD_MODULES = '/tla2sany/StandardModules';
-const TLA_TOOLS_PLUSCAL_PARAM_SKIP_CFG_CREATION = "-nocfg";
+const TLA_TOOLS_PLUSCAL_PARAM_SKIP_CFG_CREATION = '-nocfg';
 
 let lastUsedJavaHome: string | undefined;
 let cachedJavaPath: string | undefined;

--- a/tests/suite/languages/GrammarTests.md
+++ b/tests/suite/languages/GrammarTests.md
@@ -8,7 +8,7 @@ Grammar tests are defined under [tests/suite/languages](.)
 
 A grammar test is a test file that includes annotation of the expected assigned scopes. One example is the [tlaplus-grammar-test.tla](tlaplus-grammar-test.tla).
 
-For more information on how to write a test see [vscode-tmgrammar-test](thttps://github.com/PanAeon/vscode-tmgrammar-test).
+For more information on how to write a test see [vscode-tmgrammar-test](https://github.com/PanAeon/vscode-tmgrammar-test).
 
 ## Run the tests
 To run from the command line:

--- a/tests/suite/languages/tlaplus-grammar-test-submodule.tla
+++ b/tests/suite/languages/tlaplus-grammar-test-submodule.tla
@@ -1,0 +1,37 @@
+// SYNTAX TEST "source.tlaplus" "tlaplus language grammar testcase"
+
+---- MODULE SubmoduleTest ----
+// <---- comment.line 
+//   ^^^^^^ keyword.other
+//          ^^^^^^^^^^^^^ entity.name.class
+---- MODULE InnerModule1 ----
+// <---- comment.line
+//   ^^^^^^ keyword.other
+//          ^^^^^^^^^^^^ entity.name.class
+
+Op1 == FALSE
+//<-- support.type.primitive
+//     ^^^^^ support.constant.tlaplus
+
+====
+// <---- comment.line
+
+---- MODULE InnerModule2 ----
+// <---- comment.line
+//   ^^^^^^ keyword.other
+//          ^^^^^^^^^^^^ entity.name.class
+
+Op2 == FALSE
+//<-- support.type.primitive
+//     ^^^^^ support.constant.tlaplus
+
+
+====
+// <---- comment.line
+
+Op == FALSE
+//<-- support.type.primitive
+//    ^^^^^ support.constant.tlaplus
+
+====
+// <---- comment.line


### PR DESCRIPTION
Fixes #284 
![image](https://github.com/user-attachments/assets/af37a838-a1bf-4f43-a77e-eb63111d80c6)
![image](https://github.com/user-attachments/assets/e25ba8ad-c164-4f28-98a6-025309007748)
![image](https://github.com/user-attachments/assets/5a1a5bf7-8d65-4059-8882-986ee181c98d)

I was also able to verify the update with a test.
