### PR TITLE
 Display infobox when .cfg is missing

### DIFF
--- a/src/commands/checkModel.ts
+++ b/src/commands/checkModel.ts
@@ -50,7 +50,7 @@ export async function checkModel(
         return;
     }
 
-    const specFiles = await getSpecFiles(uri, false);
+    const specFiles = await getSpecFiles(uri, true);
     if (!specFiles) {
         return;
     }


### PR DESCRIPTION
Partially reapplies: https://github.com/tlaplus/vscode-tlaplus/pull/336
When the user has set the config:
```
"editor.codeActionsOnSave": {
      "source": "explicit"
    }
```
on every save, this runs debugging#smokeTestSpec function which in turn will check for the presence of the .cfg files and trigger the dialogs on saving.

With this change, the dialogs will show up only when the user is trying to model check the currently selected spec.

Running model checking on a module without cfg:
![image](https://github.com/user-attachments/assets/16c5afa3-f49c-416a-a02f-1b8fcd219cf6)

Tested saving https://github.com/tlaplus/Examples/blob/master/specifications/PaxosHowToWinATuringAward/Consensus.tla and it doesn't trigger the alert anymore.