### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,23 @@
+---
+name: 'Bug Report'
+about: 'Report a bug in TLA+ vscode plugin.'
+labels: bug
+---
+## Description:
+<!-- 
+Please try to include a screenshot of the bug, if relevant.
+-->
+
+### Steps to reproduce:
+<!-- If it involves a spec, please include both tla and config -->
+
+### Expectations:
+<!--   
+"I was expecting this to be xx but instead it was yy"
+-->
+
+### Version Information:
+<!-- go to plugins -> TLA+ -> At the top right you can find the plugin version -->
+<!-- Please include any possibly relevant information here. Like OS, architecture and so on. -->
+* Plugin Version:
+* OS:

--- a/.github/ISSUE_TEMPLATE/doc.md
+++ b/.github/ISSUE_TEMPLATE/doc.md
@@ -1,0 +1,8 @@
+---
+name: 'Documentation Issue'
+about: 'Report missing/erroneous documentation, propose new documentation, report broken links, etc.'
+labels: documentation
+---
+<!-- Describe the documentation issue. -->
+<!-- In the case of missing/erroneous documentation, where is the error? If possible, a link/url would be great. -->
+

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,13 @@
+---
+name: 'Enhancement'
+about: 'Suggest an improvement to an existing feature.'
+labels: enhancement
+---
+<!--
+When requesting a _enhancement_, please be sure to include:
+  * Your motivation:
+    * Why do you need/want the feature? 
+    * How is it going to make you and other users more productive?
+  * How the feature should work. If it's a new button, or dropdown include a screenshot and indicate where it should live (a raw mockup would be great).
+  * Please try to be as specific and concrete as possible.
+-->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,13 @@
+---
+name: 'Feature'
+about: 'Suggest a new feature for TLA+ vscode plugin.'
+labels: feature
+---
+<!--
+When requesting a _feature_, please be sure to include:
+  * Your motivation:
+    * Why do you need/want the feature? 
+    * How is it going to make you and other users more productive?
+  * How the feature should work. If it's a new button, or dropdown include a screenshot and indicate where it should live (a raw mockup would be great).
+  * Please try to be as specific and concrete as possible.
+-->


### PR DESCRIPTION
Trying to put a standard on how bugs and other things are reported. If we can get more structured and easy to follow issues, I believe it would increase the chances of getting external contributors as well.

The nice side-effect is to get automatic tagging for the issues. 