### PR TITLE
Hides undefined from check result view for stopped state

### DIFF
--- a/src/webview/checkResultView/headerSection/index.tsx
+++ b/src/webview/checkResultView/headerSection/index.tsx
@@ -34,7 +34,7 @@ export const HeaderSection = React.memo(({checkResult}: HeaderSectionI) => {
                 <span hidden={checkResult.state !== 'R'}>
                     (<VSCodeLink onClick={vscode.stopProcess} href="#"> stop </VSCodeLink>)
                 </span>
-                <span hidden={checkResult.statusDetails === null}> :{' ' + checkResult.statusDetails} </span>
+                <span hidden={ checkResult.statusDetails === undefined || checkResult.statusDetails === null}>: {' ' + checkResult.statusDetails} </span>
             </div>
 
             <div className="timeInfo"> Start: {checkResult.startDateTimeStr}, end: {checkResult.endDateTimeStr} </div>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/8dfd98e2-1257-46be-aa2b-dfed178f66f5)


After:
![image](https://github.com/user-attachments/assets/acfc6abd-c072-469f-a790-515a4edf5ceb)
There was a null check, but undefined is not null :)
I've also removed the space before the colon:
![image](https://github.com/user-attachments/assets/c64b08c1-cb76-49d1-a0d4-1b98de3c47e6)
