### PR TITLE
PDF Generation: feature parity with the toolbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.7.0 
+
+### Enhancements
+* Generate PDF feature matching the toolbox by adding missing settings.
+
+
 ## 1.5.4 &ndash; 21st March, 2021
 
 ### Enhancements

--- a/package.json
+++ b/package.json
@@ -382,6 +382,31 @@
                     "maxLength": 1000,
                     "description": "Command to produce PDFs from .tex files."
                 },
+                "tlaplus.pdf.commentsShade": {
+                    "default": true,
+                    "type": "boolean",
+                    "scope": "application",
+                    "description": "If enabled, comments will have a gray background."
+                },
+                "tlaplus.pdf.commentsShadeColor": {
+                    "default": 0.85,
+                    "type": "number",
+                    "scope": "application",
+                    "maxLength": 10,
+                    "description": "If comments are shaded in gray, this config changes the darkness of the shading. This must be a number between 0.0 (completely black) and 1.0 (no shading)."
+                },
+                "tlaplus.pdf.numberLines": {
+                    "default": false,
+                    "type": "boolean",
+                    "scope": "application",
+                    "description": "Show line numbers in PDFs."
+                },
+                "tlaplus.pdf.noPcalShade": {
+                    "default": false,
+                    "type": "boolean",
+                    "scope": "application",
+                    "description": "Causes a PlusCal algorithm (which appear in a comment) not to be shaded.  (The algorithm's comments will be shaded.)"
+                },
                 "tlaplus.tlaps.enabled": {
                     "type": "boolean",
                     "default": false,
@@ -504,6 +529,7 @@
         "vscode:prepublish": "npm run compile -- --production",
         "compile": "node ./esbuild.js",
         "lint": "eslint --ext .ts,.tsx src/ tests/",
+        "lint:fix": "eslint --fix --ext .ts,.tsx src/ tests/",
         "watch": "npm run compile -- --watch",
         "pretest": "tsc -p ./",
         "test": "node ./out/tests/runTest.js",

--- a/src/webview/checkResultView/headerSection/index.tsx
+++ b/src/webview/checkResultView/headerSection/index.tsx
@@ -34,7 +34,8 @@ export const HeaderSection = React.memo(({checkResult}: HeaderSectionI) => {
                 <span hidden={checkResult.state !== 'R'}>
                     (<VSCodeLink onClick={vscode.stopProcess} href="#"> stop </VSCodeLink>)
                 </span>
-                <span hidden={ checkResult.statusDetails === undefined || checkResult.statusDetails === null}>: {' ' + checkResult.statusDetails} </span>
+                <span hidden={ checkResult.statusDetails === undefined
+                    || checkResult.statusDetails === null}>: {' ' + checkResult.statusDetails} </span>
             </div>
 
             <div className="timeInfo"> Start: {checkResult.startDateTimeStr}, end: {checkResult.endDateTimeStr} </div>


### PR DESCRIPTION
Fixes #348.
Adds few options to the plugin, lifted from https://github.com/tlaplus/tlaplus/blob/ab14a33e39c78e4c88e81b664b9a8c916b943cab/toolbox/org.lamport.tla.toolbox.tool.tla2tex/src/org/lamport/tla/toolbox/tool/tla2tex/handler/ProducePDFHandler.java#L106:

![image](https://github.com/user-attachments/assets/0dfc4c27-598c-43e5-8fac-4f30cd1c2bbd)

This is with comment shade option checked:
![image](https://github.com/user-attachments/assets/b88d4b95-517c-4425-9555-7bee6f3b9dde)

With shade of 0.2:
![image](https://github.com/user-attachments/assets/3c182628-8397-4147-ba75-2683815e0779)

With the numbered option:
![image](https://github.com/user-attachments/assets/be22d030-eaee-46a9-a01d-6317915c1fc3)

With no pcal shade unchecked:
![image](https://github.com/user-attachments/assets/5554e1f7-5e6f-4596-890d-ec3e58cb7bf1)

With nopcal shade checked:
![image](https://github.com/user-attachments/assets/88e12f15-0a88-4133-90b4-a66a38e57e68)
