### PR TITLE
Add diagnostic for pluscal labels inserted by translation

### DIFF
--- a/src/parsers/pluscal.ts
+++ b/src/parsers/pluscal.ts
@@ -115,7 +115,8 @@ export class TranspilerStdoutParser extends ProcessOutputHandler<DCollection> {
      */
     private tryParseAddedLabels(line: string) {
         // https://github.com/tlaplus/tlaplus/blob/21f92/tlatools/org.lamport.tlatools/src/pcal/ParseAlgorithm.java#L668
-        if (line.startsWith('The following label')) { // could be `was added` or `were added`
+        const addStartPrefixes = ['The following labels were added:', 'The following label was added:'];
+        if (addStartPrefixes.some(prefix => line.startsWith(prefix))) {
             this.nowParsingAddedLabels = true;
             return true;
         }

--- a/src/parsers/pluscal.ts
+++ b/src/parsers/pluscal.ts
@@ -53,7 +53,7 @@ export class TranspilerStdoutParser extends ProcessOutputHandler<DCollection> {
             this.errMessage = null;
         }
 
-        this.tryParseAddedLabels(line)
+        this.tryParseAddedLabels(line);
     }
 
     private tryParseUnrecoverableError(line: string): boolean {
@@ -94,7 +94,7 @@ export class TranspilerStdoutParser extends ProcessOutputHandler<DCollection> {
         return true;
     }
 
-    
+
     private addError(location: vscode.Position, message: string) {
         const locRange = new vscode.Range(location, location);
         this.result.addMessage(this.filePath, locRange, message);
@@ -102,28 +102,28 @@ export class TranspilerStdoutParser extends ProcessOutputHandler<DCollection> {
 
     /**
      * Adds info on labels added by the pluscal translated.
-     * 
+     *
      * Only takes effect if the `-reportLabels` was added to PlusCal options. Output looks like:
-     * 
+     *
      *       The following labels were added: // 1
      *           Lbl_1 at line 16, column 5
      *           Lbl_2 at line 23, column 9
-     * 
-     * 
+     *
+     *
      * So we can start looking for labels as soon as we see (1)
      * and stop as soon as we stop seeing label strings.
      */
     private tryParseAddedLabels(line: string) {
-        if (line.startsWith("The following label")) { // could be `was added` or `were added`
+        if (line.startsWith('The following label')) { // could be `was added` or `were added`
             this.nowParsingAddedLabels = true;
             return true;
-        };
+        }
         if (!this.nowParsingAddedLabels) {
-            return false
+            return false;
         }
 
-        const matcher = /^\s\s([A-Za-z0-9_]+) at line (\d+), column (\d+)$/g.exec(line)
-        if (!matcher) { // done parsing 
+        const matcher = /^\s\s([A-Za-z0-9_]+) at line (\d+), column (\d+)$/g.exec(line);
+        if (!matcher) { // done parsing
             this.nowParsingAddedLabels = false;
             return false;
         }

--- a/src/parsers/pluscal.ts
+++ b/src/parsers/pluscal.ts
@@ -23,7 +23,7 @@ export class TranspilerStdoutParser extends ProcessOutputHandler<DCollection> {
     private readonly filePath: string;
     private errMessage: string | null = null;
     private nextLineIsError = false;
-    private nowParsingAddedLabels = false; //should probably be a state machine thing
+    private nowParsingAddedLabels = false; // TODO should the parser be a state machine?
 
     constructor(source: Readable | string[] | null, filePath: string) {
         super(source, new DCollection());
@@ -114,6 +114,7 @@ export class TranspilerStdoutParser extends ProcessOutputHandler<DCollection> {
      * and stop as soon as we stop seeing label strings.
      */
     private tryParseAddedLabels(line: string) {
+        // https://github.com/tlaplus/tlaplus/blob/21f92/tlatools/org.lamport.tlatools/src/pcal/ParseAlgorithm.java#L668
         if (line.startsWith('The following label')) { // could be `was added` or `were added`
             this.nowParsingAddedLabels = true;
             return true;
@@ -122,7 +123,7 @@ export class TranspilerStdoutParser extends ProcessOutputHandler<DCollection> {
             return false;
         }
 
-        const matcher = /^\s\s([A-Za-z0-9_]+) at line (\d+), column (\d+)$/g.exec(line);
+        const matcher = /^\s\s([A-Za-z0-9_]+) at line \d+, column \d+$/g.exec(line);
         if (!matcher) { // done parsing
             this.nowParsingAddedLabels = false;
             return false;

--- a/tests/suite/parsers/pluscal.test.ts
+++ b/tests/suite/parsers/pluscal.test.ts
@@ -103,6 +103,23 @@ suite('PlusCal Transpiler Output Parser Test Suite', () => {
         ]);
     });
 
+    test('Captures custom labels', () => {
+        const stdout = [
+            'pcal.trans Version 1.11 of 31 December 2020',
+            'The following label was added:',
+            '  AQX_Z1 at line 16, column 5',
+            'Parsing completed.',
+            'Translation completed.',
+            'New file saturation2.tla written.'
+        ].join('\n');
+        assertOutput(stdout, '/Users/bob/TLA/needs_labels.tla', [
+            new vscode.Diagnostic(
+                new vscode.Range(15, 5, 15, 5),
+                'Missing label, translator inserted `AQX_Z1` here',
+                vscode.DiagnosticSeverity.Information),
+        ]);
+    });
+
     test('Captures inserted multiple labels', () => {
         const stdout = [
             'pcal.trans Version 1.11 of 31 December 2020',

--- a/tests/suite/parsers/pluscal.test.ts
+++ b/tests/suite/parsers/pluscal.test.ts
@@ -86,6 +86,45 @@ suite('PlusCal Transpiler Output Parser Test Suite', () => {
         ]);
     });
 
+    test('Captures single inserted label', () => {
+        const stdout = [
+            'pcal.trans Version 1.11 of 31 December 2020',
+            'The following label was added:',
+            '  Lbl_1 at line 16, column 5',
+            'Parsing completed.',
+            'Translation completed.',
+            'New file saturation2.tla written.'
+        ].join('\n');
+        assertOutput(stdout, '/Users/bob/TLA/needs_labels.tla', [
+            new vscode.Diagnostic(
+                new vscode.Range(15, 5, 15, 5),
+                'Missing label, translator inserted `Lbl_1` here',
+                vscode.DiagnosticSeverity.Information),
+        ]);
+    });
+
+    test('Captures inserted multiple labels', () => {
+        const stdout = [
+            'pcal.trans Version 1.11 of 31 December 2020',
+            'The following labels were added:',
+            '  Lbl_1 at line 16, column 5',
+            '  Lbl_2 at line 23, column 9',
+            'Parsing completed.',
+            'Translation completed.',
+            'New file saturation2.tla written.'
+        ].join('\n');
+        assertOutput(stdout, '/Users/bob/TLA/needs_labels.tla', [
+            new vscode.Diagnostic(
+                new vscode.Range(15, 5, 15, 5),
+                'Missing label, translator inserted `Lbl_1` here',
+                vscode.DiagnosticSeverity.Information),
+            new vscode.Diagnostic(
+                new vscode.Range(22, 9, 22, 9),
+                'Missing label, translator inserted `Lbl_2` here',
+                vscode.DiagnosticSeverity.Information)
+        ]);
+    });
+
     test('Captures multiple errors after blank message', () => {
         const stdout = [
             'pcal.trans Version 1.11 of 31 December 2020',


### PR DESCRIPTION
The PlusCal translator has a `-reportLabels` flag. When set, it will automatically add missing labels to translations and log that in the output:

```
pcal.trans Version 1.11 of 31 December 2020
The following label was added:
  Lbl_1 at line 16, column 5
Parsing completed.
Translation completed.
```

Since it's logged, we might as well tell the user about it! This PR adds an information diagnostic. Demo:

![image](https://github.com/user-attachments/assets/d73ec5ef-dfad-47ec-8178-a2f961f94fb8)

![image](https://github.com/user-attachments/assets/f8302767-db10-4751-9621-ed8b7e967ecb)

Questions: 

- Should it be a `warning` instead of `information`?
- In the long run should the pluscal parser use some kind of state machine?