### PR TITLE
Rename error trace to the more user friendly Counterexample

### DIFF
--- a/src/webview/checkResultView/errorTraceSection/errorTrace.tsx
+++ b/src/webview/checkResultView/errorTraceSection/errorTrace.tsx
@@ -16,7 +16,7 @@ export const ErrorTrace = React.memo(({errorInfo, traceId}: ErrorTraceI) => {
 
     return (
         <>
-            <VSCodePanelTab id={`error-trace-tab-${traceId}`}> Error Trace {traceId} </VSCodePanelTab>
+            <VSCodePanelTab id={`error-trace-tab-${traceId}`}> Counterexample {traceId} </VSCodePanelTab>
             <VSCodePanelView id={`error-trace-view-${traceId}`} className="flex-direction-column">
                 <div className="error-trace-options">
                     <VSCodeTextField onChange={(e) => setFilter(e.currentTarget.value)} placeholder="Filter">


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1414efbb-fc47-4560-924d-35d2d680f4d3)

Not sure if it's worth it because from docs and code we refer to this section as Error Trace.