### PR TITLE
Remove unnecessary activation events

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,14 +35,6 @@
         "Modeling"
     ],
     "activationEvents": [
-        "onLanguage:tlaplus",
-        "onCommand:tlaplus.parse",
-        "onCommand:tlaplus.model.check.run",
-        "onCommand:tlaplus.model.check.customRun",
-        "onCommand:tlaplus.exportToTex",
-        "onCommand:tlaplus.exportToPdf",
-        "onCommand:tlaplus.evaluateSelection",
-        "onCommand:tlaplus.evaluateExpression",
         "workspaceContains:**/*.tla"
     ],
     "main": "./out/main.js",


### PR DESCRIPTION
Whenever I open the extension, vscode complains that commands don't need to be added to activationEvents. 

![image](https://github.com/user-attachments/assets/db0b3ca5-0007-4a3c-a159-8b8d54532d7f)

This PR fixes that terrible oversight. The extension works normally without them.