### PR TITLE
Improve error message for wrong java home path

### DIFF
--- a/src/tla2tools.ts
+++ b/src/tla2tools.ts
@@ -240,7 +240,7 @@ function buildJavaPath(): string {
         const homeUri = pathToUri(javaHome);
         javaPath = homeUri.fsPath + path.sep + 'bin' + path.sep + javaCmd;
         if (!fs.existsSync(javaPath)) {
-            throw new ToolingError('Java executable not found. Check the Java Home setting.');
+            throw new ToolingError(`Java executable not found in "${javaPath}". Check the Java Home setting.`);
         }
     }
     return javaPath;


### PR DESCRIPTION
New error after configuring /tmp as java home setting:
![image](https://github.com/user-attachments/assets/5b5e0422-efa9-4bd9-8828-bde9a730f1ee)
Should be helpful troubleshooting.

See: https://github.com/tlaplus/vscode-tlaplus/issues/254

