### PR TITLE
Update config description for java home, Java 8 is no longer supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,7 +315,7 @@
                     "type": "string",
                     "scope": "window",
                     "default": "",
-                    "description": "Path to Java (8 or higher, 11 is recommended) home directory that should be used to run TLA+ tools.",
+                    "markdownDescription": "Path to Java 11 (or higher) home directory that should be used to run TLA+ tools (akin to JAVA_HOME). [More info](https://docs.tlapl.us/using:vscode:installing_java#configure_the_extension)",
                     "maxLength": 1000
                 },
                 "tlaplus.java.options": {
@@ -336,7 +336,7 @@
                     "type": "string",
                     "scope": "window",
                     "default": "",
-                    "description": "Additional options to pass to TLC.",
+                    "markdownDescription": "Additional options to pass to TLC. Full list of available parameters is [here](https://github.com/tlaplus/tlaplus/blob/master/general/docs/current-tools.md).",
                     "maxLength": 1000
                 },
                 "tlaplus.tlc.modelChecker.optionsPrompt": {


### PR DESCRIPTION
I've also added a link to the full list of TLC options.
![image](https://github.com/user-attachments/assets/f29c4c54-6edc-489c-918d-427f83ae2378)
![image](https://github.com/user-attachments/assets/b976967a-7e23-4a5d-bca1-56eebd05b725)
