### PR TITLE
Update binary_operator_definitions regex to not stylize commented definitions

### DIFF
--- a/languages/tlaplus-grammar.json
+++ b/languages/tlaplus-grammar.json
@@ -97,7 +97,7 @@
             }
         },
         "binary_operator_definitions": {
-            "match": "(\\w+\\s*(\\(?[-<:>=&@/%#!X\\$\\*\\+\\.\\|\\?\\^\\\\]+\\)?|\\\\[a-z]+\\s)\\s*\\w+)\\s*==(?!==)",
+            "match": "(\\w+\\s*(\\(?(?!\\\\\\*)[-<:>=&@/%#!X\\$\\*\\+\\.\\|\\?\\^\\\\]+\\)?|\\\\[a-z]+\\s)\\s*\\w+)\\s*==(?!==)",
             "captures": {
                 "1": {
                     "name": "variable.parameter"
@@ -171,7 +171,7 @@
             },
             "patterns": [
                 {
-                    "include" : "#module"
+                    "include": "#module"
                 },
                 {
                     "include": "#pluscal"

--- a/package.json
+++ b/package.json
@@ -525,7 +525,7 @@
         "watch": "npm run compile -- --watch",
         "pretest": "tsc -p ./",
         "test": "node ./out/tests/runTest.js",
-        "test:tlaplus-grammar": "vscode-tmgrammar-test ./tests/suite/languages/tlaplus-grammar-test.tla ./tests/suite/languages/tlaplus-grammar-test-submodule.tla -g ./languages/tlaplus-grammar.json -g ./languages/pluscal-grammar.json"
+        "test:tlaplus-grammar": "vscode-tmgrammar-test ./tests/suite/languages/*.tla -g ./languages/tlaplus-grammar.json -g ./languages/pluscal-grammar.json"
     },
     "devDependencies": {
         "@types/glob": "^8.1.0",

--- a/tests/suite/languages/tlaplus-grammar-test-issue-361.tla
+++ b/tests/suite/languages/tlaplus-grammar-test-issue-361.tla
@@ -1,0 +1,23 @@
+// SYNTAX TEST "source.tlaplus" "tlaplus language grammar testcase for binary definitions"
+
+---- MODULE Expect ----
+// <---- comment.line 
+//   ^^^^^^ keyword.other
+//          ^^^^^^ entity.name.class
+
+TODO == FALSE
+// <--- support.type.primitive
+//      ^^^^ support.constant.tlaplus
+
+A == TODO \* B == C
+// <- support.type.primitive
+//   ^^^^ source.tlaplus
+//         ^^^^^^^^ comment.line
+
+A == TODO \* B = C
+// <- support.type.primitive
+//   ^^^^ source.tlaplus
+//         ^^^^^^^^ comment.line
+
+====
+// <---- comment.line


### PR DESCRIPTION
As per title, this seems to be the culprit.
Diagnosed by removing the definitions from the grammar file one at a time, reload the plugin and checked against the very helpful MRE provided in #361. Removing binary_operator_definitions made it working again.
Unescaped regex:
```
(\w+\s*(\(?[-<:>=&@\/%#!X\$\*\+\.\|\?\^\\]+\)?|\\[a-z]+\s)\s*\w+)\s*==(?!==)
```
From regex101:
![image](https://github.com/user-attachments/assets/f50a97e2-c748-44e3-ab97-6d0ed840d206)

Fix: I included a negative look-behind to exclude matching whenever this string starts with the sequence "\*". It should still match `\` and `*` separately. 

I included a test for the grammar that was failing before my fix, identifying the definition in the comment as something else. Please give it a try and let me know if anything else is breaking for you.

Highlight before the patch:
![image](https://github.com/user-attachments/assets/38ccc0be-f79a-4e2b-a2bb-b1bd9e60c4fe)

Highlight after the patch:
![image](https://github.com/user-attachments/assets/55d68524-40fb-4f0b-af36-c0c515a5c1a1)

Unescaped regex:
```
(\w+\s*(\(?(?!\\\*)[-<:>=&@\/%#!X\$\*\+\.\|\?\^\\]+\)?|\\[a-z]+\s)\s*\w+)\s*==(?!==)
```
From regex101:
![image](https://github.com/user-attachments/assets/bdf65a86-ba0d-42b3-9f8b-fc847a4521b5)


-----
(just some utils) Original unescaped regex:
```
const fs = require('fs');
const jsonData = JSON.parse(fs.readFileSync('regex.json', 'utf8'));
const regex = new RegExp(jsonData.match, 'g');
console.log("Regex as a string:", regex.source);
// Write the regex back to a new JSON file
const outputJsonData = { match: regex.source };
console.log(JSON.stringify(outputJsonData, null, 2));
```

