### PR TITLE
Add direct link to the errors when they are available by looking them…

### DIFF
--- a/src/diagnostic.ts
+++ b/src/diagnostic.ts
@@ -6,7 +6,7 @@ import { pathToModuleName, pathToUri } from './common';
  */
 export class DCollection {
     private readonly modules: Map<string, string> = new Map();   // Map of checked modules names to file paths
-    private messages: DMessage[] = [];                  // Collection of diagnostic messages from the check run
+    messages: DMessage[] = [];                  // Collection of diagnostic messages from the check run
 
     public getModules(): ReadonlyMap<string, string> {
         return this.modules;
@@ -75,9 +75,10 @@ export function addDiagnostics(from: DCollection, to: DCollection): void {
 /**
  * A Diagnostic instance linked to the corresponding file.
  */
-class DMessage {
+export class DMessage {
     readonly filePath: string;
     readonly diagnostic: vscode.Diagnostic;
+    readonly position: vscode.Position;
 
     constructor(
         filePath: string,
@@ -87,5 +88,6 @@ class DMessage {
     ) {
         this.filePath = filePath;
         this.diagnostic = new vscode.Diagnostic(range, text, severity);
+        this.position = new vscode.Position(range.start.line, range.start.character);
     }
 }


### PR DESCRIPTION
… up from sany output
Fixes: #258
![image](https://github.com/user-attachments/assets/4659c681-5ffb-44ee-9325-4f39c0750138)

Honestly I'm not sure about the value proposition of this change, as the same list of errors is also available in the Problems tab:
![image](https://github.com/user-attachments/assets/2b43a272-d11d-4844-b5b8-48699e3c054d)
But it is a small change and I don't have big concerns.
For testing, I've tested it with (screenshot above):
```
---- MODULE simple ----
add(x) == 1+1
Next == add(x)
=====
```
and:
```
---- MODULE simple ----
Next == add(x)
=====
```
![image](https://github.com/user-attachments/assets/1e40d35b-ea3f-4593-b65d-ef8b9d93c1e3)

I haven't tested it with other errors.
