### PR TITLE
Swap Output tab with Error tab

### DIFF
--- a/src/webview/checkResultView/outputSection/index.tsx
+++ b/src/webview/checkResultView/outputSection/index.tsx
@@ -22,31 +22,10 @@ export const OutputSection = React.memo(({checkResult}: OutputSectionI) => {
     return (
         <section>
             <VSCodePanels id="output-panels">
-                {!emptyOutputLines(checkResult) &&
+            {!emptyErrors(checkResult) &&
                     <>
-                        <VSCodePanelTab id="output-tab-1"> Output </VSCodePanelTab>
+                        <VSCodePanelTab id="output-tab-1"> Errors </VSCodePanelTab>
                         <VSCodePanelView id="output-view-1" className="flex-direction-column">
-                            {checkResult.outputLines.map((v, index) => <OutputLineElement key={index} line={v}/>)}
-                        </VSCodePanelView>
-                    </>}
-
-                {!emptyWarnings(checkResult) &&
-                    <>
-                        <VSCodePanelTab id="output-tab-2"> Warnings </VSCodePanelTab>
-                        <VSCodePanelView id="output-view-2" className="flex-direction-column">
-                            {checkResult.warnings.map((warning: WarningInfo, warningId: number) => (
-                                <p key={warningId} className="margin-0">
-                                    {warning.lines.map((v, index) =>(
-                                        <MessageLineSpan sanyMessages={checkResult.sanyMessages}
-                                            key={index} message={v}/>))}
-                                </p>))
-                            }
-                        </VSCodePanelView>
-                    </>}
-                {!emptyErrors(checkResult) &&
-                    <>
-                        <VSCodePanelTab id="output-tab-3"> Errors </VSCodePanelTab>
-                        <VSCodePanelView id="output-view-3" className="flex-direction-column">
                             {checkResult.errors.map((error: ErrorInfo, errorId: number) => (
                                 <div key={errorId} className="margin-0">
                                     {error.lines.map((v, index) => (
@@ -54,6 +33,27 @@ export const OutputSection = React.memo(({checkResult}: OutputSectionI) => {
                                             key={index} message={v}/>))}
                                     <ErrorLink error={error} index={errorId}/>
                                 </div>))
+                            }
+                        </VSCodePanelView>
+                    </>}
+                {!emptyOutputLines(checkResult) &&
+                    <>
+                        <VSCodePanelTab id="output-tab-2"> Output </VSCodePanelTab>
+                        <VSCodePanelView id="output-view-2" className="flex-direction-column">
+                            {checkResult.outputLines.map((v, index) => <OutputLineElement key={index} line={v}/>)}
+                        </VSCodePanelView>
+                    </>}
+
+                {!emptyWarnings(checkResult) &&
+                    <>
+                        <VSCodePanelTab id="output-tab-3"> Warnings </VSCodePanelTab>
+                        <VSCodePanelView id="output-view-3" className="flex-direction-column">
+                            {checkResult.warnings.map((warning: WarningInfo, warningId: number) => (
+                                <p key={warningId} className="margin-0">
+                                    {warning.lines.map((v, index) =>(
+                                        <MessageLineSpan sanyMessages={checkResult.sanyMessages}
+                                            key={index} message={v}/>))}
+                                </p>))
                             }
                         </VSCodePanelView>
                     </>}


### PR DESCRIPTION
Such that user get to see Error tabs first if there are errors.
Fixes issue #304 
![image](https://github.com/user-attachments/assets/c9744c08-0969-456d-b35a-3f354bc6f5f5)
![image](https://github.com/user-attachments/assets/3a9eea65-1ab5-455e-aedd-8701730d59eb)

sample spec:
```
---- MODULE simple ----
EXTENDS TLC, Naturals
VARIABLES x, y
add == x' = x + 1
Init == x = 0 /\ y = 0
Next == PrintT("Hello World") \/ add
=====
```