### PR TITLE
Enhance the VSCode symbol provider by layering SANY’s parsing, particularly its level-checking, on top of the existing regex-based parsing

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -33,7 +33,7 @@ const extensionBrowserConfig = {
     format: 'cjs',
     entryPoints: ['./src/main.browser.ts'],
     outfile: './out/main.browser.js',
-    external: ['vscode'],
+    external: ['vscode', 'path', 'fs', 'os', 'child_process', 'stream'],
 };
 
 // Config for webview source code (to be run in a web-based context)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "@vscode/debugadapter": "^1.63.0",
                 "@vscode/webview-ui-toolkit": "^1.2.2",
                 "await-notify": "^1.0.1",
+                "fast-xml-parser": "^5.2.1",
                 "moment": "^2.29.4",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
@@ -1630,6 +1631,24 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
+        "node_modules/fast-xml-parser": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.1.tgz",
+            "integrity": "sha512-Kqq/ewnRACQ20e0BlQ5KqHRYWRBp7yv+jttK4Yj2yY+2ldgCoxJkrP1NHUhjypsJ+eQXlGJ/jebM3wa60s1rbQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "strnum": "^2.0.5"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
+        },
         "node_modules/fastq": {
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
@@ -2827,6 +2846,18 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/strnum": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.0.5.tgz",
+            "integrity": "sha512-YAT3K/sgpCUxhxNMrrdhtod3jckkpYwH6JAuwmUdXZsmzH1wUyzTMrrK2wYCEEqlKwrWDd35NeuUkbBy/1iK+Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/supports-color": {
             "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -555,6 +555,7 @@
         "@vscode/webview-ui-toolkit": "^1.2.2",
         "vscode-languageclient": "^9.0.0",
         "await-notify": "^1.0.1",
+        "fast-xml-parser": "^5.2.1",
         "moment": "^2.29.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/src/tla2tools.ts
+++ b/src/tla2tools.ts
@@ -49,6 +49,7 @@ export enum TlaTool {
     PLUS_CAL = 'pcal.trans',
     REPL = 'tlc2.REPL',
     SANY = 'tla2sany.SANY',
+    XMLExporter = 'tla2sany.xml.XMLExporter',
     TLC = 'tlc2.TLC',
     TEX = 'tla2tex.TLA'
 }
@@ -102,6 +103,16 @@ export async function runSany(tlaFilePath: string): Promise<ToolProcessInfo> {
         tlaFilePath,
         [ path.basename(tlaFilePath) ],
         [ makeTlaLibraryJavaOpt() ]
+    );
+}
+
+export async function runXMLExporter(tlaFilePath: string, addRetCodeHandler: boolean = true): Promise<ToolProcessInfo> {
+    return runTool(
+        TlaTool.XMLExporter,
+        tlaFilePath,
+        [ '-o', path.basename(tlaFilePath) ], // -o turns XML schema validation off.
+        [ makeTlaLibraryJavaOpt() ],
+        addRetCodeHandler
     );
 }
 
@@ -182,7 +193,8 @@ async function runTool(
     toolName: string,
     filePath: string,
     toolOptions: string[],
-    javaOptions: string[]
+    javaOptions: string[],
+    addRetCodeHandler: boolean = true
 ): Promise<ToolProcessInfo> {
     // log the arugments:
     //console.log(toolName + ': ' + filePath + ' ' + toolOptions.join(' ') + ' ' + javaOptions.join(' '));
@@ -193,7 +205,9 @@ async function runTool(
     args.push(toolName);
     toolOptions.forEach(opt => args.push(opt));
     const proc = spawn(javaPath, args, { cwd: path.dirname(filePath) });
-    addReturnCodeHandler(proc, toolName);
+    if (addRetCodeHandler) {
+        addReturnCodeHandler(proc, toolName);
+    }
     return new ToolProcessInfo(buildCommandLine(javaPath, args), proc);
 }
 

--- a/tests/runTest.ts
+++ b/tests/runTest.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 
 async function main() {
     try {
+        process.env.VSCODE_TEST = 'true';
         const extensionDevelopmentPath = path.resolve(__dirname, '../../');
         const extensionTestsPath = path.resolve(__dirname, './suite/index');
         await runTests({


### PR DESCRIPTION
If a specification is malformed and SANY fails to parse it, fallback behavior will use only the output from regex-based parsing.

[Feature]

Enabled by https://github.com/tlaplus/tlaplus/issues/1171, would be made better (performance-wise) by https://github.com/tlaplus/tlaplus/issues/1114, related to https://github.com/tlaplus/foundation/discussions/21#discussioncomment-12881094, and https://github.com/tlaplus/tlaplus/issues/1175.