### PR TITLE
Only layer SANY's parse tree iff the VSCode has been saved by the user.

### DIFF
--- a/src/symbols/tlaSymbols.ts
+++ b/src/symbols/tlaSymbols.ts
@@ -216,9 +216,13 @@ export class TlaDocumentSymbolsProvider implements vscode.DocumentSymbolProvider
         }
 
         try {
-            // Save the current document to ensure XML exporter sees latest version
             if (document.isDirty) {
-                await document.save();
+                // Do not forcefully save the document if it is dirty because that may mess with
+                // other extensions or code actions that are triggered by saving.  However,
+                // there is no point in having SANY export XML if the document is not saved
+                // because the saved document might be completely different from the one in the
+                // editor.
+                return undefined;
             }
 
             // Run XML exporter


### PR DESCRIPTION
Do not forcefully save the document if it is dirty because that may mess with other extensions or code actions that are triggered by saving.

Related to git commit 1aa4aeb4b8d6977db13e988ad230621c1f759a85

[Bug]