### PR TITLE
fix: prevent incorrect navigation on record field names (#383)

### DIFF
--- a/languages/tlaplus-grammar.json
+++ b/languages/tlaplus-grammar.json
@@ -240,12 +240,16 @@
             "name": "variable.name"
         },
         "record_fields": {
-            "match": "(?<=\\[|,)\\s*(\\w+)\\s*(?=\\|->)",
-            "captures": {
-                "1": {
-                    "name": "string.quoted.double.tlaplus"
+            "patterns": [
+                {
+                    "match": "(\\w+)\\s*(?=\\|->)",
+                    "captures": {
+                        "1": {
+                            "name": "string.quoted.double.tlaplus"
+                        }
+                    }
                 }
-            }
+            ]
         }
     }
 }

--- a/src/declarations/tlaDeclarations.ts
+++ b/src/declarations/tlaDeclarations.ts
@@ -6,7 +6,35 @@ function symbolLocations(document: vscode.TextDocument, docInfo: TlaDocumentInfo
     if (!range) {
         return undefined;
     }
-    const rawWord = document.lineAt(position.line).text.substring(range.start.character, range.end.character);
+
+    // Check if the word is preceded by a dot, which would indicate it's a record field access
+    const line = document.lineAt(position.line).text;
+    if (range.start.character > 0 && line.charAt(range.start.character - 1) === '.') {
+        // This is a record field access (e.g., state.x), not a symbol reference
+        return undefined;
+    }
+
+    // Check if the word is preceded by "!." which would indicate it's in an EXCEPT expression
+    if (range.start.character > 1 && line.substring(range.start.character - 2, range.start.character) === '!.') {
+        // This is a record field in EXCEPT expression (e.g., [state EXCEPT !.x = ...])
+        return undefined;
+    }
+
+    // Check if this is a field name in a record definition (e.g., [bar |-> value])
+    // Look for the pattern: [<whitespace><field><whitespace>|->
+    const beforeWord = line.substring(0, range.start.character);
+    const afterWord = line.substring(range.end.character);
+    if (/\[\s*$/.test(beforeWord) && /^\s*\|->/.test(afterWord)) {
+        // This is a record field definition, not a symbol reference
+        return undefined;
+    }
+    // Also check for comma-separated fields (e.g., [foo |-> 1, bar |-> 2])
+    if (/,\s*$/.test(beforeWord) && /^\s*\|->/.test(afterWord)) {
+        // This is a record field definition after a comma
+        return undefined;
+    }
+
+    const rawWord = line.substring(range.start.character, range.end.character);
     const word = trimTicks(rawWord);
     const symbols = docInfo.isPlusCalAt(position)
         ? docInfo.symbols.concat(docInfo.plusCalSymbols)
@@ -28,10 +56,10 @@ export class TlaDeclarationsProvider implements vscode.DeclarationProvider {
     provideDeclaration(
         document: vscode.TextDocument,
         position: vscode.Position,
-        token: vscode.CancellationToken
+        _token: vscode.CancellationToken
     ): vscode.ProviderResult<vscode.Declaration> {
         const docInfo = this.docInfos.get(document.uri);
-        return docInfo ? symbolLocations(document, docInfo, position) : undefined;
+        return docInfo ? symbolLocations(document, docInfo, position) || [] : undefined;
     }
 }
 
@@ -43,10 +71,10 @@ export class TlaDefinitionsProvider implements vscode.DefinitionProvider {
     provideDefinition(
         document: vscode.TextDocument,
         position: vscode.Position,
-        token: vscode.CancellationToken
+        _token: vscode.CancellationToken
     ): vscode.ProviderResult<vscode.Declaration> {
         const docInfo = this.docInfos.get(document.uri);
-        return docInfo ? symbolLocations(document, docInfo, position) : undefined;
+        return docInfo ? symbolLocations(document, docInfo, position) || [] : undefined;
     }
 }
 

--- a/tests/suite/declarations/tlaDeclarations.test.ts
+++ b/tests/suite/declarations/tlaDeclarations.test.ts
@@ -224,6 +224,28 @@ suite('TLA Declarations Provider Test Suite', () => {
             loc(doc.uri, pos(1, 10))
         ]);
     });
+
+    test('Ignores record field names in multi-line record literals', () => {
+        return assertDefinitions(doc, [
+            '---- MODULE foo ----',
+            'VARIABLES bar',
+            'MyRecord ==',
+            ' [',
+            '   key |-> 42,',
+            '   ${b}ar |-> "abc"',
+            ' ]',
+            '===='
+        ], []);
+    });
+
+    test('Ignores nested record field names', () => {
+        return assertDefinitions(doc, [
+            '---- MODULE foo ----',
+            'VARIABLES bar',
+            'Nested == [outer |-> [${b}ar |-> 42]]',
+            '===='
+        ], []);
+    });
 });
 
 async function assertDeclarations(

--- a/tests/suite/declarations/tlaDeclarations.test.ts
+++ b/tests/suite/declarations/tlaDeclarations.test.ts
@@ -184,6 +184,46 @@ suite('TLA Declarations Provider Test Suite', () => {
             '===='
         ], []);
     });
+
+    test('Ignores record field names in record literals', () => {
+        return assertDefinitions(doc, [
+            '---- MODULE foo ----',
+            'VARIABLES state',
+            'Init == state = [${x} |-> 0, y |-> 0]',
+            '===='
+        ], []);
+    });
+
+    test('Ignores record field names in record access', () => {
+        return assertDefinitions(doc, [
+            '---- MODULE foo ----',
+            'VARIABLES state',
+            'Init == state = [x |-> 0, y |-> 0]',
+            'Next == state.${x} > 0',
+            '===='
+        ], []);
+    });
+
+    test('Ignores record field names in EXCEPT expressions', () => {
+        return assertDefinitions(doc, [
+            '---- MODULE foo ----',
+            'VARIABLES state',
+            "Next == state' = [state EXCEPT !.${x} = 1]",
+            '===='
+        ], []);
+    });
+
+    test('Finds symbol before dot in record access', () => {
+        return assertDefinitions(doc, [
+            '---- MODULE foo ----',
+            'VARIABLES state',
+            'Init == state = [x |-> 0, y |-> 0]',
+            'Next == ${s}tate.x > 0',
+            '===='
+        ], [
+            loc(doc.uri, pos(1, 10))
+        ]);
+    });
 });
 
 async function assertDeclarations(


### PR DESCRIPTION
Fixes #383 - Ctrl+clicking on field names in record definitions incorrectly navigated to variables with the same name.

  - Field names in record definitions: [bar |-> value]
  - Field names in record access: state.bar
  - Field names in EXCEPT expressions: [state EXCEPT !.bar = ...]