### PR TITLE
Add simulation coverage visualization for TLCGet(stats) NDJSON files

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -63,6 +63,19 @@ const webviewCurrentProofStepConfig = {
     }
 };
 
+/** @type BuildOptions */
+const webviewCoverageConfig = {
+    ...baseConfig,
+    target: 'es2020',
+    format: 'esm',
+    tsconfig: 'tsconfig.webview.json',
+    entryPoints: ['./src/webview/coverage-view.tsx'],
+    outfile: './out/coverageView.js',
+    loader: {
+        '.ttf': 'copy', // use the file loader to handle .ttf files
+    }
+};
+
 const watchPlugin = (name) => [{
     name: 'watch-plugin',
     setup(build) {
@@ -83,12 +96,17 @@ const watchPlugin = (name) => [{
                 ...webviewCurrentProofStepConfig,
                 plugins: watchPlugin('webviewCurrentProofStepConfig')
             })).watch();
+            (await context({
+                ...webviewCoverageConfig,
+                plugins: watchPlugin('webviewCoverageConfig')
+            })).watch();
         } else {
             // Build extension
             await build(extensionConfig);
             await build(extensionBrowserConfig);
             await build(webviewConfig);
             await build(webviewCurrentProofStepConfig);
+            await build(webviewCoverageConfig);
             console.log('build complete');
         }
     } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,12 @@
                 "@vscode/debugadapter": "^1.63.0",
                 "@vscode/webview-ui-toolkit": "^1.2.2",
                 "await-notify": "^1.0.1",
+                "chart.js": "^4.4.1",
                 "express": "^5.1.0",
                 "fast-xml-parser": "^5.2.1",
                 "moment": "^2.29.4",
                 "react": "^18.2.0",
+                "react-chartjs-2": "^5.2.0",
                 "react-dom": "^18.2.0",
                 "vscode-languageclient": "^9.0.0",
                 "vscode-uri": "^3.0.7",
@@ -515,6 +517,12 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
+        },
+        "node_modules/@kurkle/color": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+            "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+            "license": "MIT"
         },
         "node_modules/@microsoft/fast-colors": {
             "version": "5.3.1",
@@ -1370,6 +1378,18 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chart.js": {
+            "version": "4.4.9",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+            "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
+            "license": "MIT",
+            "dependencies": {
+                "@kurkle/color": "^0.3.0"
+            },
+            "engines": {
+                "pnpm": ">=8"
             }
         },
         "node_modules/chokidar": {
@@ -3407,6 +3427,16 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-chartjs-2": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+            "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "chart.js": "^4.1.1",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,12 @@
                 "extensions": [
                     ".out"
                 ]
+            },
+            {
+                "id": "tlaplus_ndjson",
+                "extensions": [
+                    ".ndjson"
+                ]
             }
         ],
         "grammars": [
@@ -263,6 +269,11 @@
             {
                 "command": "tlaplus.out.visualize",
                 "title": "Visualize TLC output",
+                "category": "TLA+"
+            },
+            {
+                "command": "tlaplus.coverage.visualize",
+                "title": "Visualize simulation coverage",
                 "category": "TLA+"
             },
             {
@@ -671,6 +682,8 @@
         "@vscode/codicons": "^0.0.33",
         "@vscode/debugadapter": "^1.63.0",
         "@vscode/webview-ui-toolkit": "^1.2.2",
+        "chart.js": "^4.4.1",
+        "react-chartjs-2": "^5.2.0",
         "vscode-languageclient": "^9.0.0",
         "await-notify": "^1.0.1",
         "express": "^5.1.0",

--- a/src/commands/visualizeCoverage.ts
+++ b/src/commands/visualizeCoverage.ts
@@ -1,0 +1,37 @@
+import * as vscode from 'vscode';
+import { CoverageViewPanel } from '../panels/coverageView';
+
+export const CMD_VISUALIZE_COVERAGE = 'tlaplus.coverage.visualize';
+
+export async function visualizeCoverage(uri?: vscode.Uri, extContext?: vscode.ExtensionContext): Promise<void> {
+    if (!extContext) {
+        vscode.window.showErrorMessage('Extension context not available');
+        return;
+    }
+
+    // If no URI provided, try to get from active editor
+    if (!uri) {
+        const activeEditor = vscode.window.activeTextEditor;
+        if (activeEditor && activeEditor.document.fileName.endsWith('.ndjson')) {
+            uri = activeEditor.document.uri;
+        } else {
+            // Show file picker
+            const fileUris = await vscode.window.showOpenDialog({
+                canSelectFiles: true,
+                canSelectFolders: false,
+                canSelectMany: false,
+                filters: {
+                    'NDJSON files': ['ndjson']
+                },
+                title: 'Select simulation coverage file'
+            });
+
+            if (!fileUris || fileUris.length === 0) {
+                return;
+            }
+            uri = fileUris[0];
+        }
+    }
+
+    CoverageViewPanel.render(extContext.extensionUri, uri);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { CMD_EVALUATE_SELECTION, evaluateSelection, CMD_EVALUATE_EXPRESSION,
     evaluateExpression } from './commands/evaluateExpression';
 import { parseModule, CMD_PARSE_MODULE } from './commands/parseModule';
 import { visualizeTlcOutput, CMD_VISUALIZE_TLC_OUTPUT } from './commands/visualizeOutput';
+import { visualizeCoverage, CMD_VISUALIZE_COVERAGE } from './commands/visualizeCoverage';
 import { exportModuleToTex, exportModuleToPdf, CMD_EXPORT_TLA_TO_TEX,
     CMD_EXPORT_TLA_TO_PDF } from './commands/exportModule';
 import { TlaOnTypeFormattingEditProvider } from './formatters/tla';
@@ -84,6 +85,9 @@ export function activate(context: vscode.ExtensionContext): void {
         vscode.commands.registerCommand(
             CMD_VISUALIZE_TLC_OUTPUT,
             () => visualizeTlcOutput(context)),
+        vscode.commands.registerCommand(
+            CMD_VISUALIZE_COVERAGE,
+            (uri: vscode.Uri) => visualizeCoverage(uri, context)),
         vscode.commands.registerCommand(
             CMD_EVALUATE_SELECTION,
             () => evaluateSelection(diagnostic, context)),

--- a/src/model/coverage.ts
+++ b/src/model/coverage.ts
@@ -1,0 +1,12 @@
+export interface SimulationStats {
+    duration: number;
+    generated: number;
+    distinct: number;
+    traces: number;
+}
+
+export interface CoverageData {
+    stats: SimulationStats[];
+    fileName: string;
+    lastUpdated: Date;
+}

--- a/src/panels/coverageView.ts
+++ b/src/panels/coverageView.ts
@@ -118,7 +118,6 @@ export class CoverageViewPanel {
         const nonce = getNonce();
         const scriptUri = getUri(webview, this.extensionUri, ['out', 'coverageView.js']);
         const styleUri = getUri(webview, this.extensionUri, ['out', 'coverageView.css']);
-        const codiconsUri = getUri(webview, this.extensionUri, ['out', 'codicon.css']);
 
         return `<!DOCTYPE html>
             <html lang="en">
@@ -128,7 +127,6 @@ export class CoverageViewPanel {
                 <meta http-equiv="Content-Security-Policy"
                     content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}'; font-src ${webview.cspSource};">
                 <link href="${styleUri}" rel="stylesheet">
-                <link href="${codiconsUri}" rel="stylesheet">
                 <title>Coverage Visualization</title>
             </head>
             <body>

--- a/src/panels/coverageView.ts
+++ b/src/panels/coverageView.ts
@@ -1,0 +1,157 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import { getNonce } from './utilities/getNonce';
+import { getUri } from './utilities/getUri';
+import { CoverageData } from '../model/coverage';
+import { parseNDJSON } from '../parsers/ndjson';
+
+export class CoverageViewPanel {
+    private static readonly viewType = 'coverageVisualization';
+    private static currentPanel: CoverageViewPanel | undefined;
+
+    private readonly panel: vscode.WebviewPanel;
+    private readonly extensionUri: vscode.Uri;
+    private readonly disposables: vscode.Disposable[] = [];
+    private fileUri: vscode.Uri;
+    private fileWatcher: vscode.FileSystemWatcher | undefined;
+
+    private constructor(extensionUri: vscode.Uri, fileUri: vscode.Uri) {
+        this.extensionUri = extensionUri;
+        this.fileUri = fileUri;
+
+        this.panel = vscode.window.createWebviewPanel(
+            CoverageViewPanel.viewType,
+            `Coverage: ${vscode.workspace.asRelativePath(fileUri)}`,
+            vscode.ViewColumn.Beside,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: true,
+                localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'out')]
+            }
+        );
+
+        this.panel.iconPath = {
+            light: vscode.Uri.joinPath(extensionUri, 'resources', 'images', 'tlaplus-nightly.png'),
+            dark: vscode.Uri.joinPath(extensionUri, 'resources', 'images', 'tlaplus-nightly.png')
+        };
+
+        this.panel.webview.html = this.getWebviewContent(this.panel.webview);
+
+        this.panel.webview.onDidReceiveMessage(
+            message => this.handleMessage(message),
+            undefined,
+            this.disposables
+        );
+
+        this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
+
+        // Set up file watcher
+        this.setupFileWatcher();
+
+        // Load initial data
+        this.loadAndSendData();
+    }
+
+    public static render(extensionUri: vscode.Uri, fileUri: vscode.Uri): void {
+        if (CoverageViewPanel.currentPanel) {
+            CoverageViewPanel.currentPanel.fileUri = fileUri;
+            CoverageViewPanel.currentPanel.panel.title = `Coverage: ${vscode.workspace.asRelativePath(fileUri)}`;
+            CoverageViewPanel.currentPanel.setupFileWatcher();
+            CoverageViewPanel.currentPanel.loadAndSendData();
+            CoverageViewPanel.currentPanel.panel.reveal(vscode.ViewColumn.Beside);
+        } else {
+            CoverageViewPanel.currentPanel = new CoverageViewPanel(extensionUri, fileUri);
+        }
+    }
+
+    private setupFileWatcher(): void {
+        // Dispose existing watcher
+        if (this.fileWatcher) {
+            this.fileWatcher.dispose();
+        }
+
+        // Create new watcher
+        this.fileWatcher = vscode.workspace.createFileSystemWatcher(this.fileUri.fsPath);
+
+        this.fileWatcher.onDidChange(() => {
+            this.loadAndSendData();
+        }, undefined, this.disposables);
+
+        this.fileWatcher.onDidDelete(() => {
+            vscode.window.showWarningMessage('Coverage file was deleted');
+            this.panel.webview.postMessage({ type: 'fileDeleted' });
+        }, undefined, this.disposables);
+    }
+
+    private async loadAndSendData(): Promise<void> {
+        try {
+            const content = await fs.promises.readFile(this.fileUri.fsPath, 'utf-8');
+            const stats = parseNDJSON(content);
+
+            const coverageData: CoverageData = {
+                stats,
+                fileName: vscode.workspace.asRelativePath(this.fileUri),
+                lastUpdated: new Date()
+            };
+
+            this.panel.webview.postMessage({
+                type: 'update',
+                data: coverageData
+            });
+        } catch (error) {
+            vscode.window.showErrorMessage(`Failed to read coverage file: ${error}`);
+        }
+    }
+
+    private handleMessage(message: { type: string }): void {
+        switch (message.type) {
+            case 'ready':
+                this.loadAndSendData();
+                break;
+            case 'refresh':
+                this.loadAndSendData();
+                break;
+        }
+    }
+
+    private getWebviewContent(webview: vscode.Webview): string {
+        const nonce = getNonce();
+        const scriptUri = getUri(webview, this.extensionUri, ['out', 'coverageView.js']);
+        const styleUri = getUri(webview, this.extensionUri, ['out', 'coverageView.css']);
+        const codiconsUri = getUri(webview, this.extensionUri, ['out', 'codicon.css']);
+
+        return `<!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <meta http-equiv="Content-Security-Policy"
+                    content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}'; font-src ${webview.cspSource};">
+                <link href="${styleUri}" rel="stylesheet">
+                <link href="${codiconsUri}" rel="stylesheet">
+                <title>Coverage Visualization</title>
+            </head>
+            <body>
+                <div id="root"></div>
+                <script nonce="${nonce}" src="${scriptUri}"></script>
+            </body>
+            </html>`;
+    }
+
+    private dispose(): void {
+        CoverageViewPanel.currentPanel = undefined;
+
+        if (this.fileWatcher) {
+            this.fileWatcher.dispose();
+        }
+
+        this.panel.dispose();
+
+        while (this.disposables.length) {
+            const disposable = this.disposables.pop();
+            if (disposable) {
+                disposable.dispose();
+            }
+        }
+    }
+}

--- a/src/parsers/ndjson.ts
+++ b/src/parsers/ndjson.ts
@@ -17,7 +17,7 @@ export function parseNDJSON(content: string): SimulationStats[] {
                     traces: data.traces || 0
                 };
             } catch (e) {
-                console.error('Failed to parse NDJSON line:', line, e);
+                // Invalid JSON line, skip it
                 return null;
             }
         })

--- a/src/parsers/ndjson.ts
+++ b/src/parsers/ndjson.ts
@@ -1,0 +1,25 @@
+import { SimulationStats } from '../model/coverage';
+
+export function parseNDJSON(content: string): SimulationStats[] {
+    if (!content || content.trim().length === 0) {
+        return [];
+    }
+
+    return content.trim().split('\n')
+        .filter(line => line.trim().length > 0)
+        .map(line => {
+            try {
+                const data = JSON.parse(line);
+                return {
+                    duration: data.duration || 0,
+                    generated: data.generated || 0,
+                    distinct: data.distinct || 0,
+                    traces: data.traces || 0
+                };
+            } catch (e) {
+                console.error('Failed to parse NDJSON line:', line, e);
+                return null;
+            }
+        })
+        .filter((item): item is SimulationStats => item !== null);
+}

--- a/src/parsers/ndjson.ts
+++ b/src/parsers/ndjson.ts
@@ -11,10 +11,10 @@ export function parseNDJSON(content: string): SimulationStats[] {
             try {
                 const data = JSON.parse(line);
                 return {
-                    duration: data.duration || 0,
-                    generated: data.generated || 0,
-                    distinct: data.distinct || 0,
-                    traces: data.traces || 0
+                    duration: data.duration ?? 0,
+                    generated: data.generated ?? 0,
+                    distinct: data.distinct ?? 0,
+                    traces: data.traces ?? 0
                 };
             } catch (e) {
                 // Invalid JSON line, skip it

--- a/src/webview/common/formatters.ts
+++ b/src/webview/common/formatters.ts
@@ -1,0 +1,29 @@
+/**
+ * Formats a duration in seconds to a human-readable string
+ * @param seconds The duration in seconds
+ * @param compact Whether to use compact format (for charts) or full format
+ * @returns Formatted duration string
+ */
+export function formatDuration(seconds: number, compact = false): string {
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    const secs = seconds % 60;
+
+    if (compact) {
+        if (hours > 0) {
+            return `${hours}h${minutes > 0 ? ` ${minutes}m` : ''}`;
+        } else if (minutes > 0) {
+            return `${minutes}m`;
+        } else {
+            return `${secs}s`;
+        }
+    } else {
+        if (hours > 0) {
+            return `${hours}h ${minutes}m ${secs}s`;
+        } else if (minutes > 0) {
+            return `${minutes}m ${secs}s`;
+        } else {
+            return `${secs}s`;
+        }
+    }
+}

--- a/src/webview/coverage-view.tsx
+++ b/src/webview/coverage-view.tsx
@@ -19,7 +19,6 @@ const CoverageViewApp = React.memo(({ data }: CoverageViewAppProps) => {
                 {data && <CoverageChart data={data} />}
                 {!data && (
                     <div className="loading">
-                        <vscode-progress-ring></vscode-progress-ring>
                         <p>Loading coverage data...</p>
                     </div>
                 )}

--- a/src/webview/coverage-view.tsx
+++ b/src/webview/coverage-view.tsx
@@ -3,25 +3,51 @@ import { createRoot } from 'react-dom/client';
 import { CoverageData } from '../model/coverage';
 import { CoverageChart } from './coverageView/coverageChart';
 import { CoverageHeader } from './coverageView/coverageHeader';
+import { CoverageFileDeleted } from './coverageView/coverageFileDeleted';
 import { vscode } from './coverageView/vscode';
 
 import '@vscode/codicons/dist/codicon.css';
+import './coverageView/index.css';
+
+type ViewState =
+    | { type: 'loading' }
+    | { type: 'loaded'; data: CoverageData }
+    | { type: 'file-deleted'; fileName?: string }
+    | { type: 'error'; message: string };
 
 interface CoverageViewAppProps {
-    data: CoverageData | null;
+    state: ViewState;
 }
 
-const CoverageViewApp = React.memo(({ data }: CoverageViewAppProps) => {
+const CoverageViewApp = React.memo(({ state }: CoverageViewAppProps) => {
     return (
         <React.StrictMode>
             <div className="coverage-view-container">
-                {data && <CoverageHeader data={data} />}
-                {data && <CoverageChart data={data} />}
-                {!data && (
-                    <div className="loading">
-                        <p>Loading coverage data...</p>
-                    </div>
-                )}
+                {(() => {
+                    switch (state.type) {
+                        case 'loading':
+                            return (
+                                <div className="loading">
+                                    <p>Loading coverage data...</p>
+                                </div>
+                            );
+                        case 'loaded':
+                            return (
+                                <>
+                                    <CoverageHeader data={state.data} />
+                                    <CoverageChart data={state.data} />
+                                </>
+                            );
+                        case 'file-deleted':
+                            return <CoverageFileDeleted fileName={state.fileName} />;
+                        case 'error':
+                            return (
+                                <div className="error">
+                                    <p>Error: {state.message}</p>
+                                </div>
+                            );
+                    }
+                })()}
             </div>
         </React.StrictMode>
     );
@@ -29,8 +55,10 @@ const CoverageViewApp = React.memo(({ data }: CoverageViewAppProps) => {
 
 const root = createRoot(document.getElementById('root') as HTMLElement);
 
-function render(data: CoverageData | null) {
-    root.render(<CoverageViewApp data={data} />);
+let lastKnownFileName: string | undefined;
+
+function render(state: ViewState) {
+    root.render(<CoverageViewApp state={state} />);
 }
 
 // Handle messages from extension
@@ -40,20 +68,26 @@ window.addEventListener('message', (event) => {
     switch (message.type) {
         case 'update':
             vscode.setState(message.data);
-            render(message.data);
+            if (message.data) {
+                lastKnownFileName = message.data.fileName;
+                render({ type: 'loaded', data: message.data });
+            }
             break;
         case 'fileDeleted':
-            render(null);
+            vscode.setState(null);
+            render({ type: 'file-deleted', fileName: lastKnownFileName });
             break;
     }
 });
 
 // Load initial state
 window.addEventListener('load', () => {
-    const state = vscode.getState() as CoverageData | null;
-    if (state) {
-        render(state);
+    const savedData = vscode.getState() as CoverageData | null;
+    if (savedData) {
+        lastKnownFileName = savedData.fileName;
+        render({ type: 'loaded', data: savedData });
     } else {
+        render({ type: 'loading' });
         // Signal to extension that webview is ready
         vscode.postMessage({ type: 'ready' });
     }

--- a/src/webview/coverage-view.tsx
+++ b/src/webview/coverage-view.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { createRoot } from 'react-dom/client';
+import { CoverageData } from '../model/coverage';
+import { CoverageChart } from './coverageView/coverageChart';
+import { CoverageHeader } from './coverageView/coverageHeader';
+import { vscode } from './coverageView/vscode';
+
+import '@vscode/codicons/dist/codicon.css';
+
+interface CoverageViewAppProps {
+    data: CoverageData | null;
+}
+
+const CoverageViewApp = React.memo(({ data }: CoverageViewAppProps) => {
+    return (
+        <React.StrictMode>
+            <div className="coverage-view-container">
+                {data && <CoverageHeader data={data} />}
+                {data && <CoverageChart data={data} />}
+                {!data && (
+                    <div className="loading">
+                        <vscode-progress-ring></vscode-progress-ring>
+                        <p>Loading coverage data...</p>
+                    </div>
+                )}
+            </div>
+        </React.StrictMode>
+    );
+});
+
+const root = createRoot(document.getElementById('root') as HTMLElement);
+
+function render(data: CoverageData | null) {
+    root.render(<CoverageViewApp data={data} />);
+}
+
+// Handle messages from extension
+window.addEventListener('message', (event) => {
+    const message = event.data;
+
+    switch (message.type) {
+        case 'update':
+            vscode.setState(message.data);
+            render(message.data);
+            break;
+        case 'fileDeleted':
+            render(null);
+            break;
+    }
+});
+
+// Load initial state
+window.addEventListener('load', () => {
+    const state = vscode.getState() as CoverageData | null;
+    if (state) {
+        render(state);
+    } else {
+        // Signal to extension that webview is ready
+        vscode.postMessage({ type: 'ready' });
+    }
+});

--- a/src/webview/coverageView/coverageChart.css
+++ b/src/webview/coverageView/coverageChart.css
@@ -1,0 +1,56 @@
+.coverage-chart-container {
+    padding: 16px;
+    height: calc(100vh - 200px); /* Adjust based on header height */
+    display: flex;
+    flex-direction: column;
+}
+
+.chart-wrapper {
+    flex: 1;
+    position: relative;
+    min-height: 400px;
+}
+
+.chart-info {
+    margin-top: 16px;
+    padding: 12px;
+    background-color: var(--vscode-textBlockQuote-background);
+    border-left: 3px solid var(--vscode-textBlockQuote-border);
+    border-radius: 3px;
+}
+
+.info-text {
+    margin: 0;
+    color: var(--vscode-foreground);
+    font-size: 13px;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+.info-text .codicon {
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+
+/* Loading state */
+.loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    gap: 16px;
+}
+
+.loading p {
+    color: var(--vscode-descriptionForeground);
+    font-size: 14px;
+}
+
+/* Container styles */
+.coverage-view-container {
+    height: 100vh;
+    overflow: auto;
+    background-color: var(--vscode-editor-background);
+}

--- a/src/webview/coverageView/coverageChart.tsx
+++ b/src/webview/coverageView/coverageChart.tsx
@@ -1,0 +1,202 @@
+import * as React from 'react';
+import { useEffect, useRef } from 'react';
+import { CoverageData } from '../../model/coverage';
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Legend,
+    ChartOptions,
+    ChartData
+} from 'chart.js';
+import { Line } from 'react-chartjs-2';
+import './coverageChart.css';
+
+// Register Chart.js components
+ChartJS.register(
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Legend
+);
+
+interface CoverageChartProps {
+    data: CoverageData;
+}
+
+export const CoverageChart: React.FC<CoverageChartProps> = ({ data }) => {
+    const chartRef = useRef<ChartJS<'line'>>(null);
+
+    // Format duration for x-axis labels
+    const formatDuration = (seconds: number): string => {
+        const hours = Math.floor(seconds / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+
+        if (hours > 0) {
+            return `${hours}h${minutes > 0 ? ` ${minutes}m` : ''}`;
+        } else if (minutes > 0) {
+            return `${minutes}m`;
+        } else {
+            return `${seconds}s`;
+        }
+    };
+
+    // Prepare chart data
+    const chartData: ChartData<'line'> = {
+        labels: data.stats.map(stat => formatDuration(stat.duration)),
+        datasets: [
+            {
+                label: 'Generated States',
+                data: data.stats.map(stat => stat.generated),
+                borderColor: 'rgb(59, 130, 246)', // Blue
+                backgroundColor: 'rgba(59, 130, 246, 0.1)',
+                tension: 0.1,
+                pointRadius: 3,
+                pointHoverRadius: 5,
+            },
+            {
+                label: 'Distinct States',
+                data: data.stats.map(stat => stat.distinct),
+                borderColor: 'rgb(34, 197, 94)', // Green
+                backgroundColor: 'rgba(34, 197, 94, 0.1)',
+                tension: 0.1,
+                pointRadius: 3,
+                pointHoverRadius: 5,
+            }
+        ]
+    };
+
+    // Chart options
+    const options: ChartOptions<'line'> = {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+            title: {
+                display: true,
+                text: 'States Over Time',
+                font: {
+                    size: 16,
+                },
+                color: getComputedStyle(document.documentElement).getPropertyValue('--vscode-foreground'),
+            },
+            legend: {
+                position: 'top' as const,
+                labels: {
+                    color: getComputedStyle(document.documentElement).getPropertyValue('--vscode-foreground'),
+                },
+            },
+            tooltip: {
+                mode: 'index',
+                intersect: false,
+                callbacks: {
+                    label: (context) => {
+                        const label = context.dataset.label || '';
+                        const value = context.parsed.y.toLocaleString();
+                        return `${label}: ${value}`;
+                    }
+                }
+            },
+        },
+        scales: {
+            x: {
+                display: true,
+                title: {
+                    display: true,
+                    text: 'Duration',
+                    color: getComputedStyle(document.documentElement).getPropertyValue('--vscode-foreground'),
+                },
+                ticks: {
+                    color: getComputedStyle(document.documentElement).getPropertyValue('--vscode-foreground'),
+                },
+                grid: {
+                    color: getComputedStyle(document.documentElement).getPropertyValue('--vscode-panel-border'),
+                }
+            },
+            y: {
+                display: true,
+                title: {
+                    display: true,
+                    text: 'Number of States',
+                    color: getComputedStyle(document.documentElement).getPropertyValue('--vscode-foreground'),
+                },
+                ticks: {
+                    color: getComputedStyle(document.documentElement).getPropertyValue('--vscode-foreground'),
+                    callback: function(value) {
+                        return value.toLocaleString();
+                    }
+                },
+                grid: {
+                    color: getComputedStyle(document.documentElement).getPropertyValue('--vscode-panel-border'),
+                }
+            }
+        },
+        interaction: {
+            mode: 'nearest',
+            axis: 'x',
+            intersect: false
+        }
+    };
+
+    // Update chart colors when theme changes
+    useEffect(() => {
+        const updateChartColors = () => {
+            if (chartRef.current) {
+                const chart = chartRef.current;
+                const foreground = getComputedStyle(document.documentElement).getPropertyValue('--vscode-foreground');
+                const border = getComputedStyle(document.documentElement).getPropertyValue('--vscode-panel-border');
+
+                // Update title
+                if (chart.options.plugins?.title) {
+                    chart.options.plugins.title.color = foreground;
+                }
+
+                // Update legend
+                if (chart.options.plugins?.legend?.labels) {
+                    chart.options.plugins.legend.labels.color = foreground;
+                }
+
+                // Update scales
+                if (chart.options.scales) {
+                    ['x', 'y'].forEach(axis => {
+                        const scale = chart.options.scales?.[axis];
+                        if (scale) {
+                            if (scale.title) {scale.title.color = foreground;}
+                            if (scale.ticks) {scale.ticks.color = foreground;}
+                            if (scale.grid) {scale.grid.color = border;}
+                        }
+                    });
+                }
+
+                chart.update();
+            }
+        };
+
+        // Listen for theme changes
+        const observer = new MutationObserver(updateChartColors);
+        observer.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+
+        return () => observer.disconnect();
+    }, []);
+
+    return (
+        <div className="coverage-chart-container">
+            <div className="chart-wrapper">
+                <Line ref={chartRef} data={chartData} options={options} />
+            </div>
+            <div className="chart-info">
+                <p className="info-text">
+                    <span className="codicon codicon-info"></span>
+                    The chart shows how states are discovered over time during simulation.
+                    A plateauing curve may indicate that the simulation has explored most reachable states.
+                </p>
+            </div>
+        </div>
+    );
+};

--- a/src/webview/coverageView/coverageFileDeleted.css
+++ b/src/webview/coverageView/coverageFileDeleted.css
@@ -1,0 +1,97 @@
+.file-deleted-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 60vh;
+    padding: 32px;
+    text-align: center;
+}
+
+.file-deleted-icon {
+    font-size: 48px;
+    color: var(--vscode-foreground);
+    opacity: 0.5;
+    margin-bottom: 16px;
+}
+
+.file-deleted-container h2 {
+    font-size: 24px;
+    font-weight: 600;
+    color: var(--vscode-foreground);
+    margin: 0 0 16px 0;
+}
+
+.file-deleted-message {
+    font-size: 14px;
+    color: var(--vscode-descriptionForeground);
+    margin-bottom: 32px;
+    max-width: 400px;
+}
+
+.file-deleted-instructions {
+    background-color: var(--vscode-textBlockQuote-background);
+    border-left: 3px solid var(--vscode-textBlockQuote-border);
+    border-radius: 3px;
+    padding: 16px 24px;
+    margin-bottom: 24px;
+    text-align: left;
+    max-width: 500px;
+}
+
+.file-deleted-instructions p {
+    margin: 0 0 8px 0;
+    font-weight: 500;
+}
+
+.file-deleted-instructions ul {
+    margin: 0;
+    padding-left: 20px;
+}
+
+.file-deleted-instructions li {
+    margin: 4px 0;
+    color: var(--vscode-descriptionForeground);
+}
+
+.file-deleted-instructions kbd {
+    background-color: var(--vscode-keybindingLabel-background);
+    color: var(--vscode-keybindingLabel-foreground);
+    border: 1px solid var(--vscode-keybindingLabel-border);
+    border-radius: 3px;
+    padding: 2px 4px;
+    font-family: var(--vscode-editor-font-family);
+    font-size: 11px;
+}
+
+.file-deleted-action {
+    margin-top: 8px;
+}
+
+.vscode-button {
+    background-color: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+    border: 1px solid var(--vscode-button-border, transparent);
+    padding: 4px 14px;
+    font-size: 13px;
+    line-height: 18px;
+    border-radius: 2px;
+    cursor: pointer;
+    font-family: var(--vscode-font-family);
+    font-weight: 400;
+    outline: none;
+    transition: background-color 0.1s ease-in-out;
+}
+
+.vscode-button:hover {
+    background-color: var(--vscode-button-hoverBackground);
+}
+
+.vscode-button:focus {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: 2px;
+}
+
+.vscode-button:active {
+    transform: scale(0.98);
+}

--- a/src/webview/coverageView/coverageFileDeleted.tsx
+++ b/src/webview/coverageView/coverageFileDeleted.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { vscode } from './vscode';
+import './coverageFileDeleted.css';
+
+interface CoverageFileDeletedProps {
+    fileName?: string;
+}
+
+export const CoverageFileDeleted: React.FC<CoverageFileDeletedProps> = ({ fileName }) => {
+    const handleOpenFile = () => {
+        vscode.executeCommand('tlaplus.coverage.visualize');
+    };
+
+    return (
+        <div className="file-deleted-container">
+            <div className="file-deleted-icon">
+                <i className="codicon codicon-file"></i>
+            </div>
+            <h2>Coverage File Deleted</h2>
+            <p className="file-deleted-message">
+                {fileName
+                    ? `The file "${fileName}" has been deleted.`
+                    : 'The coverage file has been deleted.'}
+            </p>
+            <div className="file-deleted-instructions">
+                <p>To visualize another coverage file:</p>
+                <ul>
+                    <li>Use Command Palette (<kbd>Ctrl+Shift+P</kbd> or <kbd>Cmd+Shift+P</kbd>)</li>
+                    <li>Run "TLA+: Visualize simulation coverage"</li>
+                </ul>
+            </div>
+            <div className="file-deleted-action">
+                <button className="vscode-button" onClick={handleOpenFile}>
+                    Open Another File
+                </button>
+            </div>
+        </div>
+    );
+};

--- a/src/webview/coverageView/coverageHeader.css
+++ b/src/webview/coverageView/coverageHeader.css
@@ -50,3 +50,28 @@
     display: flex;
     gap: 8px;
 }
+
+.icon-button {
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--vscode-foreground);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.2s;
+}
+
+.icon-button:hover {
+    background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.icon-button:active {
+    background-color: var(--vscode-toolbar-activeBackground);
+}
+
+.icon-button .codicon {
+    font-size: 16px;
+}

--- a/src/webview/coverageView/coverageHeader.css
+++ b/src/webview/coverageView/coverageHeader.css
@@ -1,0 +1,52 @@
+.coverage-header {
+    border-bottom: 1px solid var(--vscode-panel-border);
+    padding: 16px;
+    background-color: var(--vscode-editor-background);
+}
+
+.header-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+}
+
+.header-info h2 {
+    margin: 0 0 12px 0;
+    font-size: 18px;
+    font-weight: 500;
+    color: var(--vscode-foreground);
+}
+
+.stats-summary {
+    display: flex;
+    gap: 24px;
+    margin-bottom: 8px;
+}
+
+.stat-item {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.stat-label {
+    color: var(--vscode-descriptionForeground);
+    font-size: 13px;
+}
+
+.stat-value {
+    color: var(--vscode-foreground);
+    font-weight: 500;
+    font-size: 14px;
+}
+
+.last-updated {
+    color: var(--vscode-descriptionForeground);
+    font-size: 12px;
+    margin-top: 4px;
+}
+
+.header-actions {
+    display: flex;
+    gap: 8px;
+}

--- a/src/webview/coverageView/coverageHeader.tsx
+++ b/src/webview/coverageView/coverageHeader.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { CoverageData } from '../../model/coverage';
+import { vscode } from './vscode';
+import './coverageHeader.css';
+
+interface CoverageHeaderProps {
+    data: CoverageData;
+}
+
+export const CoverageHeader: React.FC<CoverageHeaderProps> = ({ data }) => {
+    const handleRefresh = () => {
+        vscode.postMessage({ type: 'refresh' });
+    };
+
+    const lastStat = data.stats[data.stats.length - 1];
+    const formatDuration = (seconds: number): string => {
+        const hours = Math.floor(seconds / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+        const secs = seconds % 60;
+
+        if (hours > 0) {
+            return `${hours}h ${minutes}m ${secs}s`;
+        } else if (minutes > 0) {
+            return `${minutes}m ${secs}s`;
+        } else {
+            return `${secs}s`;
+        }
+    };
+
+    return (
+        <div className="coverage-header">
+            <div className="header-content">
+                <div className="header-info">
+                    <h2>📊 Simulation Coverage: {data.fileName}</h2>
+                    <div className="stats-summary">
+                        {lastStat && (
+                            <>
+                                <span className="stat-item">
+                                    <span className="stat-label">Duration:</span>
+                                    <span className="stat-value">{formatDuration(lastStat.duration)}</span>
+                                </span>
+                                <span className="stat-item">
+                                    <span className="stat-label">Generated:</span>
+                                    <span className="stat-value">{lastStat.generated.toLocaleString()}</span>
+                                </span>
+                                <span className="stat-item">
+                                    <span className="stat-label">Distinct:</span>
+                                    <span className="stat-value">{lastStat.distinct.toLocaleString()}</span>
+                                </span>
+                                <span className="stat-item">
+                                    <span className="stat-label">Traces:</span>
+                                    <span className="stat-value">{lastStat.traces.toLocaleString()}</span>
+                                </span>
+                            </>
+                        )}
+                    </div>
+                    <div className="last-updated">
+                        Last updated: {new Date(data.lastUpdated).toLocaleTimeString()}
+                    </div>
+                </div>
+                <div className="header-actions">
+                    <vscode-button appearance="icon" onClick={handleRefresh}>
+                        <span className="codicon codicon-refresh"></span>
+                    </vscode-button>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/webview/coverageView/coverageHeader.tsx
+++ b/src/webview/coverageView/coverageHeader.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { VSCodeButton } from '@vscode/webview-ui-toolkit/react';
 import { CoverageData } from '../../model/coverage';
 import { vscode } from './vscode';
 import { formatDuration } from '../common/formatters';
@@ -48,9 +47,9 @@ export const CoverageHeader: React.FC<CoverageHeaderProps> = ({ data }) => {
                     </div>
                 </div>
                 <div className="header-actions">
-                    <VSCodeButton appearance="icon" onClick={handleRefresh}>
+                    <button className="icon-button" onClick={handleRefresh} title="Refresh">
                         <span className="codicon codicon-refresh"></span>
-                    </VSCodeButton>
+                    </button>
                 </div>
             </div>
         </div>

--- a/src/webview/coverageView/coverageHeader.tsx
+++ b/src/webview/coverageView/coverageHeader.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
+import { VSCodeButton } from '@vscode/webview-ui-toolkit/react';
 import { CoverageData } from '../../model/coverage';
 import { vscode } from './vscode';
+import { formatDuration } from '../common/formatters';
 import './coverageHeader.css';
 
 interface CoverageHeaderProps {
@@ -13,19 +15,6 @@ export const CoverageHeader: React.FC<CoverageHeaderProps> = ({ data }) => {
     };
 
     const lastStat = data.stats[data.stats.length - 1];
-    const formatDuration = (seconds: number): string => {
-        const hours = Math.floor(seconds / 3600);
-        const minutes = Math.floor((seconds % 3600) / 60);
-        const secs = seconds % 60;
-
-        if (hours > 0) {
-            return `${hours}h ${minutes}m ${secs}s`;
-        } else if (minutes > 0) {
-            return `${minutes}m ${secs}s`;
-        } else {
-            return `${secs}s`;
-        }
-    };
 
     return (
         <div className="coverage-header">
@@ -59,9 +48,9 @@ export const CoverageHeader: React.FC<CoverageHeaderProps> = ({ data }) => {
                     </div>
                 </div>
                 <div className="header-actions">
-                    <vscode-button appearance="icon" onClick={handleRefresh}>
+                    <VSCodeButton appearance="icon" onClick={handleRefresh}>
                         <span className="codicon codicon-refresh"></span>
-                    </vscode-button>
+                    </VSCodeButton>
                 </div>
             </div>
         </div>

--- a/src/webview/coverageView/index.css
+++ b/src/webview/coverageView/index.css
@@ -1,0 +1,31 @@
+.coverage-view-container {
+    height: 100vh;
+    overflow: auto;
+}
+
+.loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 60vh;
+    font-size: 14px;
+    color: var(--vscode-descriptionForeground);
+}
+
+.error {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 60vh;
+    padding: 32px;
+    text-align: center;
+}
+
+.error p {
+    color: var(--vscode-errorForeground);
+    background-color: var(--vscode-inputValidation-errorBackground);
+    border: 1px solid var(--vscode-inputValidation-errorBorder);
+    padding: 12px 16px;
+    border-radius: 3px;
+    max-width: 500px;
+}

--- a/src/webview/coverageView/vscode.ts
+++ b/src/webview/coverageView/vscode.ts
@@ -56,6 +56,20 @@ class VSCodeApiWrapper {
             return newState;
         }
     }
+
+    /**
+     * Execute a command in VS Code.
+     *
+     * @param command The command identifier to execute
+     * @param args Optional arguments for the command
+     */
+    public executeCommand(command: string, ...args: unknown[]) {
+        this.postMessage({
+            type: 'command',
+            command,
+            args
+        });
+    }
 }
 
 // Export singleton to prevent multiple invocations of acquireVsCodeApi

--- a/src/webview/coverageView/vscode.ts
+++ b/src/webview/coverageView/vscode.ts
@@ -1,0 +1,62 @@
+import { WebviewApi } from 'vscode-webview';
+
+/**
+ * A utility wrapper around the acquireVsCodeApi() function that enables
+ * message passing and state management between the webview and the extension.
+ *
+ * This should be called out once during the webview's initialization.
+ * Afterward, exported function wrappers can be used to interact with the extension.
+ */
+class VSCodeApiWrapper {
+    private readonly vsCodeApi: WebviewApi<unknown> | undefined;
+
+    constructor() {
+        // Check if the acquireVsCodeApi function exists in the current development
+        // context (i.e. VS Code development window or web browser)
+        if (typeof acquireVsCodeApi === 'function') {
+            this.vsCodeApi = acquireVsCodeApi();
+        }
+    }
+
+    /**
+     * Post a message (i.e. send arbitrary data) to the extension.
+     *
+     * @param message Arbitrary data (must be JSON serializable) to send to the extension
+     */
+    public postMessage(message: unknown) {
+        if (this.vsCodeApi) {
+            this.vsCodeApi.postMessage(message);
+        }
+    }
+
+    /**
+     * Get the persistent state stored for this webview.
+     *
+     * @return The current state or undefined if no state has been set
+     */
+    public getState(): unknown | undefined {
+        if (this.vsCodeApi) {
+            return this.vsCodeApi.getState();
+        } else {
+            const state = localStorage.getItem('vscodeState');
+            return state ? JSON.parse(state) : undefined;
+        }
+    }
+
+    /**
+     * Set the persistent state stored for this webview.
+     *
+     * @param newState New persisted state. This must be a JSON serializable object.
+     */
+    public setState<T extends unknown | undefined>(newState: T): T {
+        if (this.vsCodeApi) {
+            return this.vsCodeApi.setState(newState);
+        } else {
+            localStorage.setItem('vscodeState', JSON.stringify(newState));
+            return newState;
+        }
+    }
+}
+
+// Export singleton to prevent multiple invocations of acquireVsCodeApi
+export const vscode = new VSCodeApiWrapper();

--- a/tests/suite/parsers/ndjson.test.ts
+++ b/tests/suite/parsers/ndjson.test.ts
@@ -1,0 +1,72 @@
+import * as assert from 'assert';
+import { parseNDJSON } from '../../../src/parsers/ndjson';
+
+suite('NDJSON Parser Test Suite', () => {
+    test('should parse valid NDJSON data', () => {
+        const input = `{"traces":100,"duration":60,"generated":1000,"distinct":500}
+{"traces":200,"duration":120,"generated":2000,"distinct":800}`;
+        
+        const result = parseNDJSON(input);
+        
+        assert.strictEqual(result.length, 2);
+        assert.strictEqual(result[0].traces, 100);
+        assert.strictEqual(result[0].duration, 60);
+        assert.strictEqual(result[0].generated, 1000);
+        assert.strictEqual(result[0].distinct, 500);
+        
+        assert.strictEqual(result[1].traces, 200);
+        assert.strictEqual(result[1].duration, 120);
+        assert.strictEqual(result[1].generated, 2000);
+        assert.strictEqual(result[1].distinct, 800);
+    });
+
+    test('should handle empty input', () => {
+        const result = parseNDJSON('');
+        assert.strictEqual(result.length, 0);
+    });
+
+    test('should handle whitespace-only input', () => {
+        const result = parseNDJSON('   \n  \n  ');
+        assert.strictEqual(result.length, 0);
+    });
+
+    test('should skip invalid JSON lines', () => {
+        const input = `{"traces":100,"duration":60,"generated":1000,"distinct":500}
+invalid json line
+{"traces":200,"duration":120,"generated":2000,"distinct":800}`;
+        
+        const result = parseNDJSON(input);
+        assert.strictEqual(result.length, 2);
+    });
+
+    test('should handle missing fields with defaults', () => {
+        const input = `{"traces":100}
+{"duration":120,"generated":2000}`;
+        
+        const result = parseNDJSON(input);
+        assert.strictEqual(result.length, 2);
+        
+        // First line has traces but missing other fields
+        assert.strictEqual(result[0].traces, 100);
+        assert.strictEqual(result[0].duration, 0);
+        assert.strictEqual(result[0].generated, 0);
+        assert.strictEqual(result[0].distinct, 0);
+        
+        // Second line missing traces
+        assert.strictEqual(result[1].traces, 0);
+        assert.strictEqual(result[1].duration, 120);
+        assert.strictEqual(result[1].generated, 2000);
+        assert.strictEqual(result[1].distinct, 0);
+    });
+
+    test('should parse real TLC output format', () => {
+        const input = `{"traces":34008,"duration":60,"generated":4494285,"behavior":{"actions":{},"id":34001},"worker":0,"distinct":114033,"distinctvalues":{"view":12906},"retries":1072284,"actions":{"TLCInit":3863},"levelmean":40,"levelvariance":3598}`;
+        
+        const result = parseNDJSON(input);
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].traces, 34008);
+        assert.strictEqual(result[0].duration, 60);
+        assert.strictEqual(result[0].generated, 4494285);
+        assert.strictEqual(result[0].distinct, 114033);
+    });
+});

--- a/tests/suite/parsers/ndjson.test.ts
+++ b/tests/suite/parsers/ndjson.test.ts
@@ -5,15 +5,15 @@ suite('NDJSON Parser Test Suite', () => {
     test('should parse valid NDJSON data', () => {
         const input = `{"traces":100,"duration":60,"generated":1000,"distinct":500}
 {"traces":200,"duration":120,"generated":2000,"distinct":800}`;
-        
+
         const result = parseNDJSON(input);
-        
+
         assert.strictEqual(result.length, 2);
         assert.strictEqual(result[0].traces, 100);
         assert.strictEqual(result[0].duration, 60);
         assert.strictEqual(result[0].generated, 1000);
         assert.strictEqual(result[0].distinct, 500);
-        
+
         assert.strictEqual(result[1].traces, 200);
         assert.strictEqual(result[1].duration, 120);
         assert.strictEqual(result[1].generated, 2000);
@@ -34,7 +34,7 @@ suite('NDJSON Parser Test Suite', () => {
         const input = `{"traces":100,"duration":60,"generated":1000,"distinct":500}
 invalid json line
 {"traces":200,"duration":120,"generated":2000,"distinct":800}`;
-        
+
         const result = parseNDJSON(input);
         assert.strictEqual(result.length, 2);
     });
@@ -42,16 +42,16 @@ invalid json line
     test('should handle missing fields with defaults', () => {
         const input = `{"traces":100}
 {"duration":120,"generated":2000}`;
-        
+
         const result = parseNDJSON(input);
         assert.strictEqual(result.length, 2);
-        
+
         // First line has traces but missing other fields
         assert.strictEqual(result[0].traces, 100);
         assert.strictEqual(result[0].duration, 0);
         assert.strictEqual(result[0].generated, 0);
         assert.strictEqual(result[0].distinct, 0);
-        
+
         // Second line missing traces
         assert.strictEqual(result[1].traces, 0);
         assert.strictEqual(result[1].duration, 120);
@@ -60,8 +60,10 @@ invalid json line
     });
 
     test('should parse real TLC output format', () => {
-        const input = `{"traces":34008,"duration":60,"generated":4494285,"behavior":{"actions":{},"id":34001},"worker":0,"distinct":114033,"distinctvalues":{"view":12906},"retries":1072284,"actions":{"TLCInit":3863},"levelmean":40,"levelvariance":3598}`;
-        
+        const input = '{"traces":34008,"duration":60,"generated":4494285,"behavior":{"actions":{},"id":34001},' +
+            '"worker":0,"distinct":114033,"distinctvalues":{"view":12906},"retries":1072284,' +
+            '"actions":{"TLCInit":3863},"levelmean":40,"levelvariance":3598}';
+
         const result = parseNDJSON(input);
         assert.strictEqual(result.length, 1);
         assert.strictEqual(result[0].traces, 34008);


### PR DESCRIPTION
First step towards #355


- New command: "Visualize simulation coverage" that opens NDJSON files containing TLC simulation statistics (for the `ndjson` test file, I used these traces https://github.com/tlaplus/vscode-tlaplus/issues/355#issue-2737204869)
- Line graphs showing traces, generated states, and distinct states over simulation time
- NDJSON parsing

---


Select this:
![image](https://github.com/user-attachments/assets/3fc0f827-c759-4569-b699-d64f2b7c39df)

Then:

![image](https://github.com/user-attachments/assets/146e18c7-3b23-477c-80cc-8aeabab4c83f)
