### PR TITLE
fix: start proof marker

### DIFF
--- a/src/tlaps.ts
+++ b/src/tlaps.ts
@@ -269,7 +269,7 @@ export class TlapsClient {
             });
             markers.forEach(marker => {
                 const start = new vscode.Position(marker.range.start.line, marker.range.start.character);
-                const end = new vscode.Position(marker.range.start.line, marker.range.end.character);
+                const end = new vscode.Position(marker.range.end.line, marker.range.end.character);
                 const range = new vscode.Range(start, end);
                 if (marker.range.start.line === marker.range.end.line) {
                     decorations.get(marker.status + '.first')?.push({


### PR DESCRIPTION
Fixes a bug where proof step markers (TLAPS) only displayed on the first line of multi-line proof obligations. The end position was using start.line instead of end.line when creating the decoration range.

I don't know if there are any open issues on this one @lemmy @FedericoPonzi 