### PR TITLE
fix: correct typo in TLA+ grammar test expectation

### DIFF
--- a/tests/suite/languages/tlaplus-grammar-test.tla
+++ b/tests/suite/languages/tlaplus-grammar-test.tla
@@ -16,7 +16,7 @@ TCTypeOK ==
   (*************************************************************************)
   rmState \in [RM -> {"working", "prepared", "committed", "aborted"}]
 // <~-------  ^^^ support.type.primitive
-//                    ^^^^^^^^ string.quoted.doublte.tlaplus
+//                    ^^^^^^^^ string.quoted.double.tlaplus
 
 TCInit ==   rmState = [rm \in RM |-> "working"]
   (*************************************************************************)


### PR DESCRIPTION
Adjusts to the typo fix introduced here 
https://github.com/tlaplus/vscode-tlaplus/pull/382/files (line 56)