### PR TITLE
feat: enhance TLA+ grammar with categorized operator highlighting

### DIFF
--- a/languages/tlaplus-grammar.json
+++ b/languages/tlaplus-grammar.json
@@ -41,8 +41,38 @@
             "match": "\\b(?:IF|THEN|ELSE|CASE|OTHER)\\b"
         },
         "embedded_operators": {
-            "match": "\\\\[a-zA-Z]+\\b",
-            "name": "keyword.operator.tlaplus"
+            "patterns": [
+                {
+                    "comment": "Set operators",
+                    "match": "\\\\(in|notin|subseteq|subset|supseteq|supset|union|intersect|cup|cap|setminus)\\b",
+                    "name": "keyword.operator.set.tlaplus"
+                },
+                {
+                    "comment": "Logic operators",
+                    "match": "\\\\(land|lor|lnot|neg|equiv|implies|iff)\\b",
+                    "name": "keyword.operator.logic.tlaplus"
+                },
+                {
+                    "comment": "Arithmetic operators",
+                    "match": "\\\\(leq|geq|ll|gg|prec|succ|preceq|succeq|sim|simeq|asymp|approx|cong|neq|doteq|propto|models|perp|mid|parallel|bowtie|ltimes|rtimes|div|cdot|star|circ|bullet|wr|oplus|ominus|otimes|oslash|odot|dagger|ddagger)\\b",
+                    "name": "keyword.operator.arithmetic.tlaplus"
+                },
+                {
+                    "comment": "Quantifiers",
+                    "match": "\\\\(A|E|forall|exists)\\b",
+                    "name": "keyword.operator.quantifier.tlaplus"
+                },
+                {
+                    "comment": "Arrows",
+                    "match": "\\\\(times|X)\\b",
+                    "name": "keyword.operator.product.tlaplus"
+                },
+                {
+                    "comment": "Other embedded operators",
+                    "match": "\\\\[a-zA-Z]+\\b",
+                    "name": "keyword.operator.tlaplus"
+                }
+            ]
         },
         "constants": {
             "name": "support.constant.tlaplus",
@@ -147,6 +177,106 @@
             "match": "\\b(\\w+')",
             "name": "variable.name"
         },
+        "temporal_operators": {
+            "patterns": [
+                {
+                    "comment": "Box (always) operator",
+                    "match": "\\[\\]",
+                    "name": "keyword.operator.temporal.always.tlaplus"
+                },
+                {
+                    "comment": "Diamond (eventually) operator",
+                    "match": "<>",
+                    "name": "keyword.operator.temporal.eventually.tlaplus"
+                },
+                {
+                    "comment": "Leads-to operator",
+                    "match": "~>",
+                    "name": "keyword.operator.temporal.leadsto.tlaplus"
+                },
+                {
+                    "comment": "Action brackets",
+                    "match": "\\[([^\\]]+)\\]_\\w+",
+                    "name": "keyword.operator.temporal.action.tlaplus",
+                    "captures": {
+                        "1": {
+                            "patterns": [{"include": "source.tlaplus"}]
+                        }
+                    }
+                },
+                {
+                    "comment": "Angle action",
+                    "match": "<([^>]+)>_\\w+",
+                    "name": "keyword.operator.temporal.action.tlaplus",
+                    "captures": {
+                        "1": {
+                            "patterns": [{"include": "source.tlaplus"}]
+                        }
+                    }
+                }
+            ]
+        },
+        "sequences": {
+            "patterns": [
+                {
+                    "comment": "Sequence/tuple notation",
+                    "begin": "<<",
+                    "end": ">>",
+                    "name": "meta.sequence.tlaplus",
+                    "beginCaptures": {
+                        "0": {"name": "punctuation.definition.sequence.begin.tlaplus"}
+                    },
+                    "endCaptures": {
+                        "0": {"name": "punctuation.definition.sequence.end.tlaplus"}
+                    },
+                    "patterns": [
+                        {"include": "source.tlaplus"}
+                    ]
+                }
+            ]
+        },
+        "set_comprehension": {
+            "patterns": [
+                {
+                    "comment": "Set comprehension",
+                    "match": "(\\{)([^:]+)(:)([^}]+)(\\})",
+                    "captures": {
+                        "1": {"name": "punctuation.definition.set.begin.tlaplus"},
+                        "2": {
+                            "patterns": [{"include": "source.tlaplus"}]
+                        },
+                        "3": {"name": "keyword.operator.set.tlaplus"},
+                        "4": {
+                            "patterns": [{"include": "source.tlaplus"}]
+                        },
+                        "5": {"name": "punctuation.definition.set.end.tlaplus"}
+                    }
+                }
+            ]
+        },
+        "function_construction": {
+            "patterns": [
+                {
+                    "comment": "Function construction [x \\in S |-> expr]",
+                    "match": "(\\[)([^\\|]+)(\\|->)([^\\]]+)(\\])",
+                    "captures": {
+                        "1": {"name": "punctuation.definition.function.begin.tlaplus"},
+                        "2": {
+                            "patterns": [{"include": "source.tlaplus"}]
+                        },
+                        "3": {"name": "keyword.operator.function.tlaplus"},
+                        "4": {
+                            "patterns": [{"include": "source.tlaplus"}]
+                        },
+                        "5": {"name": "punctuation.definition.function.end.tlaplus"}
+                    }
+                }
+            ]
+        },
+        "range_operator": {
+            "match": "\\.\\.",
+            "name": "keyword.operator.range.tlaplus"
+        },
         "module": {
             "begin": "(\\s*-{4,}\\s*)(MODULE)\\s*(\\w+)\\s*(-{4,})",
             "beginCaptures": {
@@ -226,6 +356,21 @@
                 },
                 {
                     "include": "#primed_operators"
+                },
+                {
+                    "include": "#temporal_operators"
+                },
+                {
+                    "include": "#sequences"
+                },
+                {
+                    "include": "#set_comprehension"
+                },
+                {
+                    "include": "#function_construction"
+                },
+                {
+                    "include": "#range_operator"
                 },
                 {
                     "include": "#except_vars"

--- a/tests/suite/languages/tlaplus-grammar-test-extended.tla
+++ b/tests/suite/languages/tlaplus-grammar-test-extended.tla
@@ -1,0 +1,109 @@
+// SYNTAX TEST "source.tlaplus" "Extended TLA+ grammar test"
+
+---- MODULE ExtendedGrammarTest ----
+
+(* Test mathematical operators *)
+TestSetOps == 
+  /\ x \in S
+//     ^^^ keyword.operator.set.tlaplus
+  /\ y \notin T
+//     ^^^^^^ keyword.operator.set.tlaplus
+  /\ A \subseteq B
+//     ^^^^^^^^^ keyword.operator.set.tlaplus
+  /\ C \subset D
+//     ^^^^^^^ keyword.operator.set.tlaplus
+  /\ E \cup F = G
+//     ^^^^ keyword.operator.set.tlaplus
+  /\ H \cap I = J
+//     ^^^^ keyword.operator.set.tlaplus
+  /\ K \union L = M
+//     ^^^^^^ keyword.operator.set.tlaplus
+  /\ N \intersect O = P
+//     ^^^^^^^^^^ keyword.operator.set.tlaplus
+
+(* Test logic operators *)
+TestLogicOps ==
+  /\ P \land Q
+//     ^^^^^ keyword.operator.logic.tlaplus
+  /\ R \lor S
+//     ^^^^ keyword.operator.logic.tlaplus
+  /\ \lnot T
+//   ^^^^^ keyword.operator.logic.tlaplus
+  /\ U \equiv V
+//     ^^^^^^ keyword.operator.logic.tlaplus
+  /\ W \implies X
+//     ^^^^^^^^ keyword.operator.logic.tlaplus
+
+(* Test arithmetic operators *)
+TestArithOps ==
+  /\ a \leq b
+//     ^^^^ keyword.operator.arithmetic.tlaplus
+  /\ c \geq d
+//     ^^^^ keyword.operator.arithmetic.tlaplus
+  /\ e \neq f
+//     ^^^^ keyword.operator.arithmetic.tlaplus
+  /\ g \div h
+//     ^^^^ keyword.operator.arithmetic.tlaplus
+
+(* Test quantifiers *)
+TestQuantifiers ==
+  /\ \A x \in S : P(x)
+//   ^^ keyword.operator.quantifier.tlaplus
+  /\ \E y \in T : Q(y)
+//   ^^ keyword.operator.quantifier.tlaplus
+  /\ \forall z \in U : R(z)
+//   ^^^^^^^ keyword.operator.quantifier.tlaplus
+  /\ \exists w \in V : S(w)
+//   ^^^^^^^ keyword.operator.quantifier.tlaplus
+
+(* Test temporal operators *)
+TestTemporalOps ==
+  /\ []Invariant
+//   ^^ keyword.operator.temporal.always.tlaplus
+  /\ <>Eventually
+//   ^^ keyword.operator.temporal.eventually.tlaplus
+  /\ P ~> Q
+//     ^^ keyword.operator.temporal.leadsto.tlaplus
+  /\ [Next]_vars
+//   ^ keyword.operator.temporal.action.tlaplus
+  /\ <Next>_vars
+//   ^ keyword.operator.temporal.action.tlaplus
+
+(* Test sequences *)
+TestSequences ==
+  /\ seq = <<1, 2, 3>>
+//         ^^ punctuation.definition.sequence.begin.tlaplus
+//                  ^^ punctuation.definition.sequence.end.tlaplus
+  /\ <<a, b, c>> \in Seq(S)
+//   ^^ punctuation.definition.sequence.begin.tlaplus
+//            ^^ punctuation.definition.sequence.end.tlaplus
+
+(* Test set comprehension *)
+TestSetComprehension ==
+  /\ {x \in S : P(x)}
+//   ^ punctuation.definition.set.begin.tlaplus
+//            ^ keyword.operator.set.tlaplus
+//                  ^ punctuation.definition.set.end.tlaplus
+
+(* Test function construction *)
+TestFunctionConstruction ==
+  /\ [x \in Domain |-> f(x)]
+//   ^ punctuation.definition.function.begin.tlaplus
+//                 ^^^ keyword.operator.function.tlaplus
+//                         ^ punctuation.definition.function.end.tlaplus
+
+(* Test range operator *)
+TestRange ==
+  /\ 1..10
+//    ^^ keyword.operator.range.tlaplus
+  /\ a..b
+//    ^^ keyword.operator.range.tlaplus
+
+(* Test product operator *)
+TestProduct ==
+  /\ S \X T
+//     ^^ keyword.operator.product.tlaplus
+  /\ A \times B
+//     ^^^^^^ keyword.operator.product.tlaplus
+
+====


### PR DESCRIPTION
This PR improves the TLA+ syntax highlighting by classifying operators into semantic groups (set, logic, arithmetic, temporal, and whatnot)

Note: Visual distinction between operator categories depends on the VS Code theme being used. Most themes treat `all keyword.operator.*` scopes the same, but this could help in custom theming.  Could look like this:

![image](https://github.com/user-attachments/assets/661c93b7-74ad-4ac6-bc6c-f60a71b52f09)
