### PR TITLE
ci: add TLA+ grammar tests to CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
     - name: Test Linux
       if: matrix.os == 'ubuntu-latest'
       run: xvfb-run --auto-servernum npm test --silent
+    - name: Test TLA+ Grammar
+      run: npm run test:tlaplus-grammar
     - name: Upload artifact
       if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
       run: |
         npm run lint
         npm test --silent
+        npm run test:tlaplus-grammar
     - name: Publish to Marketplace
       run: |
         vsce publish $(git log -1 --format=%cd --date="format:%Y.%-m.%-d%H%M") --pat "${{ secrets.VSCODE_MARKETPLACE_TLAPLUS_TOKEN }}"


### PR DESCRIPTION
Both CI workflows now include TLA+ grammar tests.
  - ci.yml: to run grammar tests on push/PR for all platforms
  - release.yml: to run grammar tests before publishing as part of quality checks