### PR TITLE
Add first batch of TLA+ knowledge base articles as resources to MCP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@cocalc/ansi-to-react": "^7.0.0",
                 "@microsoft/fast-components": "^2.30.6",
                 "@microsoft/fast-react-wrapper": "^0.3.18",
-                "@modelcontextprotocol/sdk": "^1.11.2",
+                "@modelcontextprotocol/sdk": "^1.17.2",
                 "@vscode/codicons": "^0.0.33",
                 "@vscode/debugadapter": "^1.63.0",
                 "@vscode/webview-ui-toolkit": "^1.2.2",
@@ -580,15 +580,17 @@
             }
         },
         "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.11.2",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.2.tgz",
-            "integrity": "sha512-H9vwztj5OAqHg9GockCQC06k1natgcxWQSRpQcPJf6i5+MWBzfKkRtxGbjQf0X2ihii0ffLZCRGbYV2f2bjNCQ==",
+            "version": "1.17.2",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.2.tgz",
+            "integrity": "sha512-EFLRNXR/ixpXQWu6/3Cu30ndDFIFNaqUXcTqsGebujeMan9FzhAaFFswLRiFj61rgygDRr8WO1N+UijjgRxX9g==",
             "license": "MIT",
             "dependencies": {
+                "ajv": "^6.12.6",
                 "content-type": "^1.0.5",
                 "cors": "^2.8.5",
-                "cross-spawn": "^7.0.3",
+                "cross-spawn": "^7.0.5",
                 "eventsource": "^3.0.2",
+                "eventsource-parser": "^3.0.0",
                 "express": "^5.0.1",
                 "express-rate-limit": "^7.5.0",
                 "pkce-challenge": "^5.0.0",
@@ -1135,7 +1137,6 @@
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -1559,9 +1560,10 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -2111,8 +2113,7 @@
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "node_modules/fast-glob": {
             "version": "3.3.1",
@@ -2145,8 +2146,7 @@
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
@@ -2773,8 +2773,7 @@
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -3374,7 +3373,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
             "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -4087,7 +4085,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }

--- a/package.json
+++ b/package.json
@@ -791,7 +791,7 @@
         "@cocalc/ansi-to-react": "^7.0.0",
         "@microsoft/fast-components": "^2.30.6",
         "@microsoft/fast-react-wrapper": "^0.3.18",
-        "@modelcontextprotocol/sdk": "^1.11.2",
+        "@modelcontextprotocol/sdk": "^1.17.2",
         "@vscode/codicons": "^0.0.33",
         "@vscode/debugadapter": "^1.63.0",
         "@vscode/webview-ui-toolkit": "^1.2.2",

--- a/resources/knowledgebase/tla-RandomElement.md
+++ b/resources/knowledgebase/tla-RandomElement.md
@@ -1,0 +1,30 @@
+---
+title: RandomElement vs. Non-Determinism
+description: Understanding the RandomElement operator in TLA+
+---
+
+## How To: Non-Determinism vs. RandomElement in TLA+
+
+When modeling systems in TLA+, we frequently need to express that a system can make arbitrary choices—such as picking any element from a set, or taking one of several possible actions. This is called **non-determinism**. TLA+ natively supports non-determinism through its logical operators and set constructs. For example, the following action allows `x` to take any value from the set `S`:
+
+```tla
+x' \in S
+```
+
+This means that in the next state, `x` can be any element of `S`. The model checker (TLC) will explore all possible choices for `x` in its analysis.
+
+### The RandomElement Operator
+
+You may notice that the TLC module defines an operator called `RandomElement`. This operator is **rarely used** in TLA+ modeling. In fact, in almost all cases, you should **not** use `RandomElement` when expressing non-deterministic choices. Instead, rely on TLA+'s built-in non-determinism as shown above.
+
+#### Why Not Use RandomElement?
+
+- **Non-determinism is the norm:** TLA+ is designed to model all possible behaviors, not to simulate random or probabilistic choices.
+- **Clarity and correctness:** Using non-deterministic constructs makes your specification clearer and ensures that all possible behaviors are considered.
+
+### Niche Use Cases
+
+The use of `RandomElement` is so rare and specialized that this howto does **not** document its niche applications. If you think you need `RandomElement`, reconsider your approach—there is almost always a better way to model your system using TLA+'s standard non-deterministic constructs.
+
+**Summary:**  
+When modeling in TLA+, always use non-determinism (e.g., `x' \in S`) to express arbitrary choices. Do **not** use `RandomElement`—its use is almost never appropriate in system specifications.

--- a/resources/knowledgebase/tla-choose-nondeterminism.md
+++ b/resources/knowledgebase/tla-choose-nondeterminism.md
@@ -1,0 +1,109 @@
+---
+title: Choosing Between `CHOOSE` and Non-Determinism in TLA+
+description: Understanding the differences between `CHOOSE` and non-determinism in TLA+ specifications.
+---
+
+# Choosing Between `CHOOSE` and Non-Determinism in TLA+
+
+In TLA+, both `CHOOSE` and existential quantification (`∃` or `\E`) can express that **some element** with a given property exists. However, they serve **different purposes** and should be used in **different contexts**.  `CHOOSE` is constructive—it picks one such element so you can use it as a specific value in definitions, whereas `∃` is logical—it’s used to state that such an element exists, without identifying which one.
+
+## ✅ When to Use `CHOOSE`
+
+- You need to **refer to a specific but arbitrary value** that satisfies a condition.
+- You want to **define a function** or variable deterministically based on some property.
+- The value must be **stable and consistent** (i.e., the same value is always chosen if the set of satisfying values remains unchanged).
+
+## 🚫 When *Not* to Use `CHOOSE`
+
+**Do not use `CHOOSE` to eliminate non-determinism** in a behavior specification (i.e. in `Spec`) in order to reduce state space.
+
+> Replacing non-deterministic choices with `CHOOSE` might appear to reduce the number of states, but this is misleading. It’s a bug, not a feature—it changes the meaning of the specification.
+
+CHOOSE is a deterministic choice operator. Given a condition, it selects one specific value that satisfies it—always the same value, as long as the condition and the set of satisfying values don’t change. Mathematicians refer to this idea as Hilbert’s epsilon operator (ε), which denotes "some element" satisfying a property, but in a fixed and consistent way.
+
+### Examples
+
+```tla
+CHOOSE x \in Nat : x > 5
+```
+
+> Selects **one particular natural number greater than 5**, and always returns the same one as long as the condition doesn’t change.
+
+```tla
+NULL == 
+    CHOOSE x : x \notin D
+```
+
+> Defines a unique value not in the domain `D`—commonly used to model an "uninitialized" or "null" value.
+
+```tla
+Max(S) ==
+    CHOOSE s \in S: \A t \in S: s >= t
+```
+
+> Returns the maximum value from the set `S`. Useful when defining operators that must yield a concrete value.
+
+```tla
+\* Assume `S \subseteq DOMAIN func`.
+RECURSIVE Sum(_, _)
+Sum(func, S) == 
+    IF S = {} THEN 0
+    ELSE LET x == CHOOSE x \in S : TRUE
+         IN  func[x] + Sum(func, S \ {x})
+```
+
+> Defines a recursive summation over a set `S` by choosing one element at a time. `CHOOSE` provides a way to select an element from `S` during recursion.
+
+---
+
+## Use Non-Determinism (`∃`, `\/`, etc.) when
+
+- You want to **describe possible behaviors** without specifying **which** value is chosen.
+- You are modeling **specifications**, where any value satisfying a condition is acceptable.
+- The exact choice doesn’t matter for the correctness of the spec — you care only that **some** value exists.
+
+### Examples
+
+```tla
+∃ x \in Nat : x > 5
+```
+
+> Asserts that **some** natural number greater than 5 exists — does not specify which.
+
+```tla
+CONSTANT T, V
+VARIABLE memory
+Init ==
+   memory \in [T -> V]
+
+WrongInit ==
+   memory = [t \in T |-> CHOOSE v \in V: TRUE]
+```
+
+> In `Init`, memory is initialized non-deterministically: any mapping from the set of threads `T` to the set of values `V` is valid. In `WrongInit`, memory is initialized to a specific, fixed choice of values—every `t` gets the same deterministically selected `v` from `V`. This restricts behavior and undermines the non-determinism expected in an abstract spec.
+
+```tla
+CONSTANT Nodes
+VARIABLE inbox
+SendMsg(msg) ==
+    \E recv \in Nodes:
+        inbox' = [inbox EXCEPT ![recv] = @ \cup {msg}]
+
+WrongSendMsg(msg) ==
+    LET recv == CHOOSE n \in Node: TRUE
+    IN inbox' = [inbox EXCEPT ![recv] = @ \cup {msg}]
+```
+
+> In `SendMsg`, the message `msg` may be sent to any node, allowing the spec to explore all possible receivers in the state space. In `WrongSendMsg`, the message is always sent to the same chosen node, reducing the system’s variability and potentially hiding issues that depend on message routing diversity.
+
+This is useful for:
+
+- Abstract specifications
+- Modeling non-deterministic or concurrent behavior
+- Allowing multiple valid next states in a spec
+
+---
+
+### 📝 Tip
+
+Always ask yourself: **"Do I need to refer to a particular value, or is it enough that such a value exists?"**

--- a/resources/knowledgebase/tla-diagnose-property-violations.md
+++ b/resources/knowledgebase/tla-diagnose-property-violations.md
@@ -1,0 +1,21 @@
+---
+title: How to debug INVARIANT or PROPERTY Violations
+description: A practical guide to debugging TLC model checking errors, focusing on strategies for diagnosing invariant and property violations. It outlines how to minimize configurations, verify invariants, and systematically isolate root causes of property failures.
+---
+
+## How to debug INVARIANT or PROPERTY Violations
+
+### Debugging and Diagnosing INVARIANT or PROPERTY Violations
+
+When you encounter an invariant or property violation, start by **minimizing the TLC configuration**. Simplify the model as much as possible—reduce constants, constraints, and the state space—to identify the smallest configuration that still triggers the violation. This helps isolate the root cause more effectively.
+
+### Debugging and Diagnosing PROPERTY Violations
+
+Before analyzing a `PROPERTY` violation, ensure your specification includes a sufficient set of invariants and that all of them hold.
+
+To verify this:
+
+1. Temporarily **remove the `PROPERTY` (or `PROPERTIES`) entries** from your TLC configuration.
+2. Rerun the model checker to check only the invariants.
+
+If any invariant fails, address that issue first. This step helps determine whether the `PROPERTY` violation stems from a more fundamental problem in the model, rather than the property itself.

--- a/resources/knowledgebase/tla-different-configurations.md
+++ b/resources/knowledgebase/tla-different-configurations.md
@@ -1,0 +1,15 @@
+---
+title: How to check different TLC configurations
+description: Learn how to validate TLA+ models by running TLC with multiple configurations of constant values, ensuring broader coverage and avoiding missed corner cases while managing state-space explosion.
+---
+
+## How to check different TLC configurations
+
+### Check models across combinations of constant values
+
+When using CONSTANT declarations in your TLA+ model, ensure the model is verified with multiple TLC configuration (.cfg) files, each specifying a different combination of constant values. Always start with the smallest possible configuration, then gradually increase the configuration size. Keep in mind that even a linear increase in configuration size can lead to exponential (or greater) growth in the state space, a phenomenon known as state-space explosion.
+
+### Rationale
+
+- A single constant assignment may not expose corner cases.
+- Meaningful coverage requires checking a variety of constant combinations that reflect real-world or extreme scenarios.

--- a/resources/knowledgebase/tla-empty-unchanged.md
+++ b/resources/knowledgebase/tla-empty-unchanged.md
@@ -1,0 +1,84 @@
+---
+title: The Empty UNCHANGED Operator
+description: Understanding the empty UNCHANGED operator in TLA+
+---
+
+In TLA+, the `UNCHANGED` operator is used to specify that certain variables do not change across a state transition. For example:
+
+```tla
+UNCHANGED << x, y >>
+```
+
+is shorthand for:
+
+```tla
+<< x, y >>' = << x, y >>
+```
+
+This means that both `x` and `y` retain their values between the current state and the next state.
+
+---
+
+## The empty `UNCHANGED`
+
+Occasionally, you might see (or accidentally write) the expression:
+
+```tla
+UNCHANGED << >>
+```
+
+This expands to:
+
+```tla
+<< >>' = << >>
+```
+
+Since `<< >>` is the empty tuple, it contains no declared variables. By definition, the empty tuple is always equal to itself across states. Therefore, the expression is **always `TRUE`** and contributes nothing to the specification.
+
+---
+
+## Why this matters
+
+* `UNCHANGED <<>>` has no semantic effect and can be omitted without changing the meaning of the specification.
+* If it appears in your spec, it is usually a byproduct of:
+
+  * Copy–pasting a template that lists variables in `UNCHANGED` and forgetting to fill them in.
+  * Generating code from a tool that doesn’t check for empty tuples.
+  * Removing variables from a conjunct without cleaning up the `UNCHANGED`.
+
+---
+
+## Best practice
+
+* **Avoid leaving `UNCHANGED <<>>` in your spec.** It adds no information and can distract readers.
+* If you need a placeholder in a definition where you may later add variables, it is clearer to use `TRUE` explicitly:
+
+```tla
+Next == \/ Action1
+        \/ Action2
+        \/ TRUE   \* placeholder for future actions
+```
+
+---
+
+## Example
+
+```tla
+VARIABLE x
+
+Init == x = 0
+
+Next ==
+  \/ x' = x + 1
+  \/ UNCHANGED << >>
+```
+
+Here, the second disjunct (`UNCHANGED <<>>`) is equivalent to `TRUE`. Thus, `Next` allows *any state* (since the `TRUE` disjunct always holds), which is almost certainly not the intended behavior. Removing it clarifies the specification.
+
+---
+
+## Summary
+
+* `UNCHANGED <<>>` = `TRUE`
+* It expresses nothing about the system and should be removed.
+* If you encounter it, check whether it was meant to constrain variables but was left empty by mistake.

--- a/resources/knowledgebase/tla-extends-instance.md
+++ b/resources/knowledgebase/tla-extends-instance.md
@@ -1,0 +1,106 @@
+---
+title: Understanding `EXTENDS` vs `INSTANCE` in TLA+
+description: Learn the difference between `EXTENDS` and `INSTANCE` in TLA+, when to use each, and how they handle imports, namespacing, constants, and variables.
+---
+
+In **TLA+**, `EXTENDS` and `INSTANCE` are both used to bring in definitions from other modules, but they serve **distinct purposes**.
+
+---
+
+### ✅ Use `EXTENDS` to **import definitions directly**
+
+When you `EXTEND` a module, you bring all of its public operators and definitions into your spec, as if you copied and pasted them at the top.
+
+Example:
+
+```tla
+EXTENDS Naturals, Sequences
+```
+
+This makes operators like `+`, `<`, `Len`, `Append`, etc., available without qualification.
+
+> Think of `EXTENDS` as syntactically *inlining* the target module. This is convenient but can lead to **name clashes**—especially if multiple modules define the same operator or constant name.
+
+For instance, if your module already defines `Len`, and you `EXTEND Sequences`, you’ll get a conflict since both define `Len`.
+
+---
+
+### ✅ Use `INSTANCE` for **namespacing** or **parameterization**
+
+#### 🔹 Namespacing: avoid name clashes
+
+To use another module without polluting your namespace, use `INSTANCE`. This lets you qualify all referenced operators with an instance label.
+
+Example:
+
+```tla
+---- MODULE YourSpec ----
+S == INSTANCE Sequences
+
+Len(cars) ==
+    S!Len(cars) + 1
+```
+
+Now `S!Len` refers to the `Len` from `Sequences`, and your own `Len` is unaffected.
+
+---
+
+#### 🔹 Parameterization: substitute `CONSTANTS` and `VARIABLES`
+
+If a module declares `CONSTANTS`, you may want to use `INSTANCE` to provide values via `WITH`. The same applies if the module declares `VARIABLES`: in that case, you must map those variables to expressions or variables from your own module. This is also known as a **refinement mapping**.
+
+So, `WITH` lets you:
+
+- Provide values for declared `CONSTANTS`
+- Define how the instantiated module's `VARIABLES` correspond to your module's state
+
+---
+
+#### Example
+
+```tla
+---- MODULE Stack ----
+CONSTANT Elem
+VARIABLES stack
+
+Init == stack = << >>
+Push(x) == stack' = Append(stack, x)
+Pop == stack' = Head(stack)
+Next == \E x \in Elem: Push(x) \/ Pop
+====
+```
+
+To use `Stack`, you’d write:
+
+```tla
+EXTENDS Sequences
+INSTANCE Stack WITH Elem <- {1, 2, 3}, stack <- s
+```
+
+This gives you:
+
+- Access to `Init`, `Push`, `Pop`, `Next` from `Stack`
+- With:
+  - `Elem` replaced by `{1, 2, 3}`
+  - `stack` mapped to your own module’s variable `s`
+
+> 🔁 This makes it possible to **reuse behavior** across modules while plugging in different constant values and state variables.
+
+You can also create **multiple instances** of the same module with different parameters:
+
+```tla
+S1 == INSTANCE Stack WITH Elem <- {1, 2}, stack <- s1
+S2 == INSTANCE Stack WITH Elem <- {"a", "b"}, stack <- s2
+```
+
+---
+
+### TL;DR
+
+| Use Case                        | Use `EXTENDS`                 | Use `INSTANCE`                                       |
+|--------------------------------|-------------------------------|------------------------------------------------------|
+| Bring in standard definitions  | ✅ Yes                         | ✖ Not typical                                        |
+| Avoid name clashes             | ✖ Risk of conflict            | ✅ Use qualified access (`M!Op`)                     |
+| Module has `CONSTANTS`         | ✖ Not allowed                 | ✅ Use `WITH` to provide values                      |
+| Module has `VARIABLES`         | ✖ Not allowed                 | ✅ Map to local variables (refinement)               |
+| Multiple versions with config  | ✖ Not possible                | ✅ Each instance can use different substitutions     |

--- a/resources/knowledgebase/tla-functions-operators.md
+++ b/resources/knowledgebase/tla-functions-operators.md
@@ -1,0 +1,55 @@
+---
+title: Operators vs. Functions in TLA+: Key Differences
+description: Learn the distinction between operators and functions in TLA+. Operators act like macros that expand into expressions, while functions are first-class mappings from inputs to outputs. This guide explains their definitions, usage, evaluation, and examples to help you apply them correctly in specifications.
+---
+
+## Operators vs. Functions in TLA+: Key Differences
+
+The distinction between **functions** and **operators** in **TLA+**.
+
+### 🔧 **Rule**
+>
+> **Operators** in TLA+ are symbolic or named expressions that *take arguments and produce expressions*.  
+> **Functions** are mappings from a *domain* to a *range*, where each input in the domain maps to exactly one output.
+
+---
+
+### 🧠 Think of it like this
+
+| Concept          | Operators                                                               | Functions                                                         |
+|------------------|-------------------------------------------------------------------------|-------------------------------------------------------------------|
+| **Nature**       | Logical/mathematical *expression*                                       | *Data structure* mapping inputs to outputs                        |
+| **Usage**        | Used like a *macro* or expression generator                             | Used like a value or variable                                     |
+| **Input**        | Passed explicitly via parentheses (`F(x, y)`)                           | Accessed via function application (`f[x]`)                        |
+| **Definition**   | Via `==`, e.g., `F(x) == x + 1`                                         | Via `[x ∈ S ↦ expr]`, e.g., `f == [x ∈ S ↦ x + 1]`                |
+| **Evaluation**   | Substitutes and evaluates as a formula                                  | Evaluates to a value (a function object)                          |
+| **Higher-order** | Not directly first-class (can be passed around but not quantified over) | First-class citizens (can be stored, passed, and quantified over) |
+
+---
+
+### ✅ Examples
+
+#### 1. **Operator**
+
+```tla
+Double(x) == 2 * x
+```
+
+- `Double(3)` evaluates to `6`
+- Think of `Double` as a macro that expands into `2 * x`.
+
+#### 2. **Function**
+
+```tla
+f == [x ∈ Nat ↦ 2 * x]
+```
+
+- `f[3]` evaluates to `6`
+- `f` is a value — a mapping from `Nat` to results.
+
+---
+
+### ✨ Summary Shortcut
+>
+> **Operators** are like macros that compute expressions.  
+> **Functions** are values that map inputs to outputs.

--- a/resources/knowledgebase/tla-indentation.md
+++ b/resources/knowledgebase/tla-indentation.md
@@ -1,0 +1,59 @@
+---
+title: When Indentation Matters in TLA+: Aligning Junctor Lists Correctly
+description: Indentation in TLA+ is usually ignored, but junctor lists such as disjunction and conjunction are a critical exception. Misaligned operators can cause syntax errors or change the meaning of your specification. This article explains what junctor lists are, shows examples of how indentation affects semantics, and provides best practices to keep your TLA+ specifications correct and readable.
+---
+### **When Indentation Matters in TLA+**
+
+In TLA+, indentation is **syntactically insignificant**, except when writing **junctor lists**—multi-line expressions using logical operators like **conjunction** (`/\`, "and") and **disjunction** (`\/`, "or"). Improper indentation of these lists can lead to **syntax errors**—or worse, **logical misinterpretation**.
+
+---
+
+### **What Are Junctor Lists?**
+
+A **junctor list** is a multi-line expression combining multiple boolean conditions using logical **conjunction** (`/\`) or **disjunction** (`\/`). They are typically written across multiple lines to enhance readability.
+
+---
+
+### **Proper Alignment of Junctor Lists**
+
+All operators (`/\` or `\/`) in a junctor list must be **indented consistently** and aligned vertically. The example below illustrates how varying indentation can alter the semantic meaning of a formula.
+
+```tla
+LEMMA 
+    /\ TRUE
+      \/ TRUE
+    /\ FALSE
+<=>
+    (TRUE \/ TRUE) /\ FALSE
+OBVIOUS
+
+LEMMA 
+    /\ TRUE
+      \/ TRUE
+      \/ FALSE
+<=>
+    TRUE \/ TRUE \/ FALSE
+OBVIOUS 
+
+LEMMA 
+    \/ TRUE
+    \/ TRUE
+      /\ FALSE
+<=> 
+    TRUE \/ (TRUE /\ FALSE)
+OBVIOUS
+```
+
+---
+
+### **Best Practices**
+
+* Always **align each junctor (`/\` or `\/`) in a list at the same indentation level**.
+* Avoid using tabs; use **spaces** (typically 4 per level) for consistency.
+* Prefer vertical alignment for readability and structural clarity.
+
+---
+
+### **Conclusion**
+
+In TLA+, **indentation of junctor lists is not optional**—it affects the correctness of your specification. When writing conjunctions and disjunctions across multiple lines, make sure to **align operators consistently** to ensure your specification behaves as intended.

--- a/resources/knowledgebase/tla-no-conjunct-of-invariants.md
+++ b/resources/knowledgebase/tla-no-conjunct-of-invariants.md
@@ -1,0 +1,65 @@
+---
+title: Avoid Combining Invariants in TLA+ for Clearer TLC Error Reporting
+description: When writing TLA+ specifications, avoid grouping multiple invariants into a single conjunctive expression. TLC will only report the composite failure, making it unclear which condition was violated. Instead, list each invariant separately in your TLC configuration so that errors are reported precisely, simplifying debugging and analysis.
+---
+### ⚠️ **Avoid Combining Invariants in TLA+**
+
+When writing TLA+ specifications, **do not combine multiple invariants into a single conjunctive (`/\`) expression** and then refer to that composite in your TLC configuration. If you do, **TLC will only report that the combined invariant was violated**, without indicating which specific component failed.
+
+For example, the following is discouraged:
+
+```tla
+TypeOK ==
+  /\ queue \in Seq(Nat)
+  /\ waitingProducers \subseteq Producers
+  /\ waitingConsumers \subseteq Consumers
+
+DeadlockFreedom ==
+  waiting # (Producers \cup Consumers)
+
+QueueBounded ==
+  Len(queue) <= QCapacity
+
+Inv ==
+  /\ TypeOK
+  /\ DeadlockFreedom
+  /\ QueueBounded
+```
+
+TLC config file:
+
+```cfg
+INVARIANT Inv
+```
+
+If any of the conditions fail (e.g., `QueueBounded` is violated), TLC will only indicate that `Inv` is violated—not which specific part.
+
+---
+
+### ✅ **Recommended Approach: List Invariants Separately**
+
+Instead, **declare each invariant individually** and reference each one by name in the TLC configuration. This allows TLC to pinpoint exactly which invariant failed.
+
+```tla
+TypeOK ==
+  /\ queue \in Seq(Nat)
+  /\ waitingProducers \subseteq Producers
+  /\ waitingConsumers \subseteq Consumers
+
+DeadlockFreedom ==
+  waiting # (Producers \cup Consumers)
+
+QueueBounded ==
+  Len(queue) <= QCapacity
+```
+
+TLC config file:
+
+```cfg
+INVARIANTS
+  TypeOK
+  DeadlockFreedom
+  QueueBounded
+```
+
+This way, TLC will clearly report which specific invariant(s) failed, making debugging much easier.

--- a/resources/knowledgebase/tla-pluscal.md
+++ b/resources/knowledgebase/tla-pluscal.md
@@ -1,0 +1,12 @@
+---
+title: PlusCal
+description: Understanding PlusCal
+---
+
+## PlusCal
+
+PlusCal (also written as +cal) is an imperative-style domain-specific language (DSL) built on top of TLA+. It provides a more familiar, algorithmic syntax while compiling down to TLA+ specifications.
+
+While useful for expressing algorithms in a structured way, PlusCal is less expressive than TLA+ and can represent only a subset of what TLA+ can model.
+
+⚠️ Note: Do not generate PlusCal code unless explicitly requested.

--- a/resources/knowledgebase/tla-prove-type-correctness-lemma.md
+++ b/resources/knowledgebase/tla-prove-type-correctness-lemma.md
@@ -1,0 +1,81 @@
+---
+title: Proving Type Correctness (`TypeOK`) in TLA⁺ with TLAPS
+description: Guidance for Proving Type Correctness in TLA⁺ with TLAPS
+---
+### 🔍 Guidance for Proving Type Correctness (`TypeOK`) in TLA⁺ with TLAPS
+
+To formally prove type correctness using TLAPS, follow these steps.
+All proofs must be placed in a separate file with the _proof.tla extension (e.g., MyModule_proof.tla).
+
+---
+
+#### 1. **Enable TLAPS Pragmas**
+
+Before writing the proof, ensure that the TLAPS pragmas such as `PTL`, `SMT`, etc., are available by either:
+
+* Adding `EXTENDS TLAPS`, or
+* Using `INSTANCE TLAPS`.
+
+This makes the necessary proof strategies accessible to the prover.
+
+---
+
+#### 2. **Referencing Assumptions**
+
+If your specification includes assumptions using `ASSUME`, **name** the assumption and **explicitly refer to it** in your proof using the `BY` clause.
+
+For example:
+
+```tla
+----- MODULE MyModule -----
+CONSTANT S
+
+ASSUME Assumption == S \subseteq Nat
+
+VARIABLES x
+vars == <<x>>
+
+TypeOK == x \in Nat
+
+Init == ...
+
+A == ...
+B == ...
+
+Next == A \/ B
+
+Spec == Init /\ [][Next]_vars
+=====
+
+----- MODULE MyModule_proof -----
+EXTENDS MyModule
+
+LEMMA TypeCorrect == Spec => []TypeOK
+<1>1. Init => TypeOK BY Assumption DEF Init, TypeOK
+<1>2. TypeOK /\ [Next]_vars => TypeOK' BY Assumption DEF TypeOK, Next, vars, A, B
+<1>. QED BY Assumption, <1>1, <1>2, PTL DEF Spec, TypeOK, Init, Next, A, B
+=====
+```
+
+> ✅ **Note**: Explicitly referencing `Assumption` ensures TLAPS is aware of it during the proof. Omitting this may result in unprovable steps or silent failures.
+
+---
+
+#### 3. **Invocation and Interpreting Feedback**
+
+TLAPS **must be run**—either through the **TLA⁺ extension in VSCode** or via the **command line**.
+
+**To check a proof in VSCode**:
+
+* Open the `_proof.tla` file in VSCode.
+* Right-click anywhere inside the proof and select **“TLA+: Check Prove Step in TLAPS”**, or use the command palette.
+
+**To check a proof on the command line**:
+
+* Run the following command:
+
+  ```bash
+  $ opam exec -- tlapm MyModule_proof
+  ```
+
+After running TLAPS, examine its output carefully. It will indicate whether each **proof obligation has been successfully discharged** or if **any have failed**. Use this feedback to guide your next steps—refining proof steps, adjusting assumptions, or structuring your arguments more clearly. TLAPS is not just a checker but a valuable source of insight into how your proof is interpreted and where it may need improvement.

--- a/resources/knowledgebase/tla-refinement.md
+++ b/resources/knowledgebase/tla-refinement.md
@@ -1,0 +1,77 @@
+---
+title: TLA+ Spec Refinement
+description: Understanding and verifying refinement in TLA+ specifications.
+---
+## 📏 TLA+ Spec Refinement
+
+### 🔍 What is Refinement?
+
+**Refinement** means that a **lower-level (implementation) specification** correctly implements the behavior of a **higher-level (abstract) specification**. In TLA+, this allows you to write a simple spec describing *what* a system should do, and a more detailed one describing *how* it does it—and then prove they behave consistently. In short: **Implementation Spec** refines **High-Level Spec** if every behavior of the implementation is *allowed* by the high-level spec.
+Refinement is semantic: it’s about the meaning of the specs (their behaviors), not about syntax. Specs don’t have to share variables or modules.
+
+---
+
+### ✅ How to Check Refinement with TLC
+
+**General Process:**
+
+1. Write the missing specification: either the abstract (high-level) or the concrete (implementation-level) specification, depending on which one already exists. Typically, one of the two is already defined and remains unchanged.
+2. **Instantiate the abstract specification** in the concrete one using the `INSTANCE` statement.
+3. **Define a refinement mapping** with the `WITH` clause, relating implementation variables to abstract variables, if needed.
+4. **Verify refinement using TLC** by ensuring that the abstract specification is a `PROPERTY` of the concrete specification.
+
+---
+
+### 🧪 Example
+
+Assume you have:
+
+* A high-level spec in a module named `HighLevel`
+* An implementation spec in a module named `Impl`
+
+```tla
+------------------- MODULE HighLevel -------------------
+VARIABLE counter
+
+Init == counter = 0
+Next == counter' = counter + 1
+
+Spec == Init /\ [][Next]_counter
+========================================================
+```
+
+```tla
+------------------- MODULE Impl -------------------
+EXTENDS Naturals
+
+VARIABLE x, y
+
+Init == x = 0 /\ y = 0
+Next == \/ x' = x + 1 /\ y' = y
+        \/ x' = x /\ y' = y + 1
+
+Spec == Init /\ [][Next]_<x, y>
+
+----
+
+High == INSTANCE HighLevel WITH counter <- x
+Refinement == High!Spec
+====================================================
+```
+
+In your TLC config file for `Impl`, set:
+
+```cfg
+SPECIFICATION Spec
+PROPERTY Refinement
+```
+
+This checks: "Does my implementation spec (`Spec`) refine the abstract spec (`High!Spec`)?"
+
+---
+
+### 🧠 Advanced Notes
+
+TLA+ refinement is **stuttering insensitive**. That means if your implementation does "extra steps" such as `x' = x /\ y' = y + 1` that don’t change the abstract state (the variable `counter` above), it's still a valid refinement—as long as the visible behavior aligns.
+
+> 🧠 Think of it as: the abstract spec doesn’t care *how* the result was achieved, as long as the *resulting behavior* is the same.

--- a/resources/knowledgebase/tla-stuttering.md
+++ b/resources/knowledgebase/tla-stuttering.md
@@ -1,0 +1,47 @@
+---
+title: How to Model Stuttering in TLA+
+description: How to Model Stuttering in TLA+
+---
+
+## How to Model Stuttering in TLA+
+
+### What is Stuttering?
+
+In TLA+, a *stuttering step* is a step in which the system's variables do not change. Stuttering steps are important in temporal logic because they allow behaviors to be extended with 'do nothing' steps, making specifications robust to timing and implementation details.
+
+### Stuttering is Built-In
+
+You **do not need to explicitly model stuttering steps** in TLA+. The temporal formula `[Next]_vars` automatically allows for stuttering: it is equivalent to `Next \/ vars' = vars`. This means that, at every step, the system can either take a `Next` step or do nothing (a stuttering step).
+
+### Example: Stuttering in Action
+
+Suppose you have a system with two actions, `A` and `B`. You might be tempted to add an explicit `Skip` action for stuttering, but this is unnecessary:
+
+```tla
+VARIABLES vars
+
+A == \* ... some action ...
+B == \* ... another action ...
+
+Skip ==
+    UNCHANGED vars
+
+Next ==
+    \/ A
+    \/ B
+    \* No need to add: \/ Skip
+
+Spec == Init /\ [][Next]_vars
+```
+
+Here, `[Next]_vars` means that at each step, either `Next` occurs (i.e., `A` or `B`), **or** the variables remain unchanged (a stuttering step). You do not need to define a separate `Skip` or `UNCHANGED vars` action.
+
+### Best Practices
+
+- **Never add explicit stuttering steps** (like `Skip == UNCHANGED vars`) unless you have a very specific reason.
+- Use `[Next]_vars` in your temporal formulas to get stuttering insensitivity for free.
+- Remember: all TLA+ behaviors are stuttering insensitive by default when using `[Next]_vars`.
+
+### Summary
+
+Stuttering steps are automatically included in TLA+ specifications via the `[Next]_vars` notation. You almost never need to model them explicitly. This makes your specs simpler and more robust.

--- a/resources/knowledgebase/tla-symbols-set-operations.md
+++ b/resources/knowledgebase/tla-symbols-set-operations.md
@@ -1,0 +1,42 @@
+---
+title: Write Clearer TLA+: Prefer \union and \intersect
+description: Best practices for writing readable TLA+ specifications by choosing clear set operation syntax
+---
+## How to Use Union and Intersection in TLA+
+
+When writing TLA+ specifications, it's important to prioritize readability and clarity for human readers. One small but effective way to do this is by choosing the more descriptive versions of set operators.
+
+### ✅ Preferred Syntax
+
+- Use `\union` instead of `\cup`
+- Use `\intersect` instead of `\cap`
+
+These forms are more readable because they explicitly spell out the operations, making the specification more approachable—especially for readers less familiar with mathematical shorthand.
+
+### ❌ Avoid (Though Valid)
+
+- `\cup` (valid TLA+ for union, but less readable)
+- `\cap` (valid TLA+ for intersection, but less readable)
+
+### Why This Matters
+
+While both forms are syntactically correct in TLA+, most human readers find `\union` and `\intersect` easier to understand at a glance. This aligns with how people naturally verbalize these operations ("union" and "intersection"), which can aid both comprehension and collaboration.
+
+### Example
+
+```tla
+A \union B     \* Preferred
+A \intersect B \* Preferred
+
+A \cup B       \* Avoid
+A \cap B       \* Avoid
+```
+
+### Summary
+
+| Operation    | Preferred    | Avoid  |
+| ------------ | ------------ | ------ |
+| Union        | `\union`     | `\cup` |
+| Intersection | `\intersect` | `\cap` |
+
+Choose clarity—use `\union` and `\intersect` in your TLA+ specs.


### PR DESCRIPTION
Add first batch of TLA+ knowledge base articles as resources to MCP server.

Related: https://modelcontextprotocol.io/specification/2025-06-18/server/resources