### PR TITLE
Provide auxiliary filesystem tools for TLA+ MCP server

### DIFF
--- a/package.json
+++ b/package.json
@@ -572,6 +572,12 @@
                     "default": -1,
                     "markdownDescription": "Listening port for TLA+ MCP server. If set to -1, MCP server will be disabled. Restart VSCode to apply changes."
                 },
+                "tlaplus.mcp.enableFilesystemTools": {
+                    "type": "boolean",
+                    "scope": "window",
+                    "default": false,
+                    "markdownDescription": "Enable filesystem tools (list_directory, read_file, write_file) in the MCP server. These tools allow reading and writing files within the workspace. Restart VSCode to apply changes. It is unlikely that you will want to enable this, because VSCode and Cursor already provide filesystem operations."
+                },
                 "tlaplus.pdf.convertCommand": {
                     "default": "pdflatex",
                     "type": "string",


### PR DESCRIPTION
For security reasons, they are disabled by default and must be explicitly enabled by setting the VS Code/Cursor setting
```json
"tlaplus.mcp.enableFilesystemTools": true
```    
This can be done e.g. workspace-wide in your `.vscode/settings.json` file.

The TLA+ tools (SANY, TLC, …) were built around a filesystem-centric model, which creates blockers in many workflows. While the long-term goal is to make them filesystem-agnostic, this requires a major refactoring and will not happen soon:
https://github.com/tlaplus/tlaplus/issues/719

Editors like Cursor already support filesystem operations, and those should generally be preferred. Our filesystem tools act as a fallback: they prevent failures when LLMs need to create or modify files that become input to SANY, TLC, or related MCP tools.

Requiring each MCP client to implement its own filesystem operations is another option, but this breaks down if client and server run on different hosts—clients cannot create files on the host where TLA+ tools execute.

### Implementor’s Notes:
* Tools were chosen over MCP resources: they are more widely supported, better suited for interactive use, and simpler to validate.
* Because SANY and TLC require absolute file paths, our filesystem tools also use absolute paths. For security, access is limited to files within the active VSCode or Cursor workspace.
* We chose to keep the TLA+ MCP tools file-based, even though their APIs could have been migrated to streams. The risk was unclear client behavior: MCP clients like Cursor ultimately need to write to files, since human users expect to view and manage those files directly.

### Security Notes:
No safeguards are currently in place to prevent MCP clients from writing TLA+ specifications that, for example, use the `IOUtils` module to read or write files outside of the workspace.