### PR TITLE
update error trace tree expansion handling

### DIFF
--- a/src/webview/checkResultView/errorTraceSection/errorTraceState.tsx
+++ b/src/webview/checkResultView/errorTraceSection/errorTraceState.tsx
@@ -7,37 +7,54 @@ import { ErrorTraceSettings } from './errorTrace';
 
 type TreeItemElement = HTMLElementTagNameMap['vscode-tree-item'];
 
-interface ErrorTraceStateI {errorTraceItem: ErrorTraceItem, settings: ErrorTraceSettings, expanded: boolean}
-export const ErrorTraceState = React.memo(({errorTraceItem, settings, expanded}: ErrorTraceStateI) => {
+interface ErrorTraceStateI {
+    errorTraceItem: ErrorTraceItem;
+    settings: ErrorTraceSettings;
+    registerTreeItem: (index: number, element: TreeItemElement | null) => void;
+    stateIndex: number;
+}
+
+export const ErrorTraceState = React.memo(({
+    errorTraceItem,
+    settings,
+    registerTreeItem,
+    stateIndex
+}: ErrorTraceStateI) => {
 
     const stateId = 'state-'+errorTraceItem.num;
+    const treeItemElement = React.useRef<TreeItemElement | null>(null);
 
-    // Not using onExpandedChanged because collapseAll/expandAll would also trigger that event
-    const handleExpand = (event: React.MouseEvent<TreeItemElement>) => {
-        settings.setExpandValue(errorTraceItem.num-1, event.currentTarget.open);
-    };
-    const handleExpandKey = (event: React.KeyboardEvent<TreeItemElement>) => {
-        if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
-            settings.setExpandValue(errorTraceItem.num-1, event.currentTarget.open);
+    const handleRef = React.useCallback((element: TreeItemElement | null) => {
+        treeItemElement.current = element;
+        registerTreeItem(stateIndex, element);
+    }, [registerTreeItem, stateIndex]);
+
+    React.useEffect(() => {
+        const element = treeItemElement.current;
+        if (!element) {
+            return;
         }
-    };
+        if (element.dataset.initialized !== 'true') {
+            element.open = true;
+            element.dataset.initialized = 'true';
+        }
+    }, []);
 
     return (
-        <VscodeTreeItem id={stateId} open={expanded} onClick={handleExpand} onKeyDown={handleExpandKey}>
+        <VscodeTreeItem id={stateId} ref={handleRef}>
             <div className="error-trace-title">
                 <span> {errorTraceItem.num}: {errorTraceItem.title} </span>
                 <CodeRangeLink line=' >>' filepath={errorTraceItem.filePath} range={errorTraceItem.range}/>
             </div>
 
-            {!expanded ? <VscodeTreeItem/> :
-                errorTraceItem.variables.items
-                    .map(
-                        (value) =>
-                            <ErrorTraceVariable
-                                key={value.id}
-                                value={value as CollectionValue}
-                                stateId={errorTraceItem.num}
-                                settings={settings}/>)}
+            {errorTraceItem.variables.items
+                .map(
+                    (value) =>
+                        <ErrorTraceVariable
+                            key={value.id}
+                            value={value as CollectionValue}
+                            stateId={errorTraceItem.num}
+                            settings={settings}/>)}
         </VscodeTreeItem>
     );
 });

--- a/src/webview/checkResultView/errorTraceSection/treeItemRegistry.ts
+++ b/src/webview/checkResultView/errorTraceSection/treeItemRegistry.ts
@@ -1,0 +1,33 @@
+export interface TreeItemWithOpen {
+    open: boolean;
+}
+
+export interface TreeItemRegistry<T extends TreeItemWithOpen> {
+    register: (index: number, item: T | null) => void;
+    collapseAll: () => void;
+    expandAll: () => void;
+}
+
+export const createTreeItemRegistry = <T extends TreeItemWithOpen>(): TreeItemRegistry<T> => {
+    const treeItems = new Map<number, T>();
+
+    const register = (index: number, item: T | null) => {
+        if (item) {
+            treeItems.set(index, item);
+        } else {
+            treeItems.delete(index);
+        }
+    };
+
+    const setOpenForAll = (open: boolean) => {
+        treeItems.forEach((treeItem) => {
+            treeItem.open = open;
+        });
+    };
+
+    return {
+        register,
+        collapseAll: () => setOpenForAll(false),
+        expandAll: () => setOpenForAll(true)
+    };
+};

--- a/tests/suite/webview/treeItemRegistry.test.ts
+++ b/tests/suite/webview/treeItemRegistry.test.ts
@@ -1,0 +1,52 @@
+import * as assert from 'assert';
+import { createTreeItemRegistry } from '../../../src/webview/checkResultView/errorTraceSection/treeItemRegistry';
+
+suite('Tree Item Registry', () => {
+    interface TestTreeItem {
+        open: boolean;
+    }
+
+    test('collapseAll closes every registered item', () => {
+        const registry = createTreeItemRegistry<TestTreeItem>();
+        const first: TestTreeItem = {open: true};
+        const second: TestTreeItem = {open: true};
+
+        registry.register(0, first);
+        registry.register(1, second);
+
+        registry.collapseAll();
+
+        assert.strictEqual(first.open, false);
+        assert.strictEqual(second.open, false);
+    });
+
+    test('expandAll opens every registered item', () => {
+        const registry = createTreeItemRegistry<TestTreeItem>();
+        const first: TestTreeItem = {open: false};
+        const second: TestTreeItem = {open: false};
+
+        registry.register(0, first);
+        registry.register(1, second);
+
+        registry.expandAll();
+
+        assert.strictEqual(first.open, true);
+        assert.strictEqual(second.open, true);
+    });
+
+    test('register removes items when null is provided', () => {
+        const registry = createTreeItemRegistry<TestTreeItem>();
+        const item: TestTreeItem = {open: true};
+
+        registry.register(0, item);
+        registry.collapseAll();
+        assert.strictEqual(item.open, false);
+
+        registry.register(0, null);
+
+        item.open = false;
+        registry.expandAll();
+
+        assert.strictEqual(item.open, false);
+    });
+});


### PR DESCRIPTION
- **Bug:** Reported by @lemmy in https://github.com/tlaplus/vscode-tlaplus/pull/425#issuecomment-3399662819 (this was due to a dependence on a behavior that existed in the old library)
- **Fix:** Tree items now mark themselves as branches and keep DOM refs so the collapse/expand controls toggle the real VS Code nodes



https://github.com/user-attachments/assets/e2daf946-ddfd-4926-9102-bd38b9af8fa6

