### PR TITLE
Rename extension filename before upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,12 @@ jobs:
       run: xvfb-run --auto-servernum npm test --silent
     - name: Test TLA+ Grammar
       run: npm run test:tlaplus-grammar
+    - name: Rename artifact
+      if: matrix.os == 'ubuntu-latest'
+      run: mv vscode-ide-*.vsix vscode-tlaplus-$(git log -1 --format=%cd --date="format:%Y.%-m.%-d%H%M").vsix
     - name: Upload artifact
       if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v4
       with:
         name: vscode-tlaplus-ci.vsix
-        path: ${{ github.workspace }}/vscode-ide-*.vsix
+        path: ${{ github.workspace }}/vscode-tlaplus-*.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       continue-on-error: true
       uses: actions/upload-artifact@v4
       with:
-          name: vscode-ide-1.7.0.vsix
+          name: vscode-tlaplus-release-1.7.0.vsix
           path: |
             *.vsix
     - name: Publish to Open VSX


### PR DESCRIPTION
addresses [this](https://github.com/tlaplus/vscode-tlaplus/pull/443#discussion_r2466984994) comment in my last pr.

Now the uploaded artifact for the PR shows as ` vscode-tlaplus-ci.vsix`:

<img width="1349" height="271" alt="image" src="https://github.com/user-attachments/assets/8816a8d4-a16b-4e4e-a84e-0c41733a33b9" />

once downloaded (it's a zip file):
<img width="360" height="76" alt="image" src="https://github.com/user-attachments/assets/d649c823-31cc-4306-a9c8-2c3b31233dd3" />
it has the commit's short hash id in the filename.