### PR TITLE
vsce package was renamed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         npm ci
-        npm install -g vsce
+        npm install -g @vscode/vsce 
     - name: Build
       run: |
         npm run vscode:prepublish


### PR DESCRIPTION
Get rid of this log in the CI:
> npm warn deprecated vsce@2.15.0: vsce has been renamed to @vscode/vsce. Install using @vscode/vsce instead.