### PR TITLE
Fix race condition in ToolProcessInfo mergedOutput stream ending

### DIFF
--- a/src/tla2tools.ts
+++ b/src/tla2tools.ts
@@ -71,9 +71,14 @@ export class ToolProcessInfo {
             process.stderr.pipe(this.mergedOutput, { end: false });
         }
         // Close merged stream when process ends
-        process.on('exit', () => {
+        // Attach listener before checking exit status to avoid race
+        process.once('exit', () => {
             this.mergedOutput.end();
         });
+        // If process already exited, end stream now (calling end() twice is safe)
+        if (process.exitCode !== null) {
+            this.mergedOutput.end();
+        }
     }
 }
 

--- a/tests/suite/commands/parseModule.test.ts
+++ b/tests/suite/commands/parseModule.test.ts
@@ -59,20 +59,9 @@ Spec == Init /\\ Next
             capturedOutput += chunk.toString();
         });
 
-        // Wait for stream to end
-        await new Promise((resolve) => {
+        // Wait for stream to end (production code ensures this happens)
+        await new Promise<void>((resolve) => {
             procInfo.mergedOutput.once('end', resolve);
-            if (procInfo.mergedOutput.readableEnded) {
-                resolve(null);
-            }
-        });
-
-        // Wait for 'close' event (ensures all file handles released)
-        await new Promise((resolve) => {
-            procInfo.process.once('close', resolve);
-            if (procInfo.process.exitCode !== null) {
-                resolve(null);
-            }
         });
 
         // Verify that mergedOutput captured output


### PR DESCRIPTION
ToolProcessInfo constructor attached 'exit' listener to end mergedOutput,
but on fast process exits (Windows), the listener wasn't attached in time.
Use attach-first-then-check pattern to ensure stream always ends.