### PR TITLE
Fix If-Else snippet and add If-Elsif snippet

### DIFF
--- a/languages/pluscal-snippets.json
+++ b/languages/pluscal-snippets.json
@@ -40,11 +40,22 @@
         "body": [
             "if ${1:condition} then",
             "\t${2:body}",
-            "elseif",
+            "else",
             "\t${0:body}",
             "end if;"
         ],
         "description": "If-else block"
+    },
+    "If-Elsif": {
+        "prefix": "ifel",
+        "body": [
+            "if ${1:condition} then",
+            "\t${2:body}",
+            "elsif ${3:condition} then",
+            "\t${0:body}",
+            "end if;"
+        ],
+        "description": "If-elsif block"
     },
     "With": {
         "prefix": "with",


### PR DESCRIPTION
This pull request fixes an issue where the If-Else snippet incorrectly inserted `elseif` instead of `else`.  
It now inserts `else` as intended, and a new If-Elsif snippet has been added to correctly insert `elsif`.