### PR TITLE
Fix and improve snippets

### DIFF
--- a/languages/pluscal-snippets.json
+++ b/languages/pluscal-snippets.json
@@ -102,5 +102,14 @@
             "end process;"
         ],
         "description": "Create new process"
+    },
+    "Procedure": {
+        "prefix": "procedure",
+        "body": [
+            "procedure ${1:name}(${2:params}) begin",
+            "\t${0:body}",
+            "end procedure;"
+        ],
+        "description": "Create new procedure"
     }
 }


### PR DESCRIPTION
This PR includes the following changes:

- Fix If-Elsif prefix to avoid duplication with If-Else
- Add Elsif and Else clause snippets for convenience
- Add missing description to Process
- Add Procedure snippet

Note: I introduced the If-ElsIf mistake in #461, and I apologize for the oversight.
