### PR TITLE
Fix merged stream end timing

### DIFF
--- a/src/tla2tools.ts
+++ b/src/tla2tools.ts
@@ -75,9 +75,11 @@ export class ToolProcessInfo {
         process.once('exit', () => {
             this.mergedOutput.end();
         });
-        // If process already exited, end stream now (calling end() twice is safe)
+        // If the process already exited before listeners are attached, end the merged
+        // stream on the next tick so late subscribers still observe the `end` event.
+        // Calling end() twice is safe because PassThrough ignores subsequent calls.
         if (process.exitCode !== null) {
-            this.mergedOutput.end();
+            setImmediate(() => this.mergedOutput.end());
         }
     }
 }


### PR DESCRIPTION
- Problem: SANY can exit instantly; we ended the merged output stream immediately, so late-attaching listeners missed the end event and Mocha waited 10 seconds then failed
- Fix: if the process is already exited, defer mergedOutput.end() with setImmediate, giving listeners one tick to subscribe before the end event fires