### PR TITLE
Programmatically register MCP server in Cursor

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -271,10 +271,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     if (typeof mcpPort === 'number' && (mcpPort >= 1024 && mcpPort <= 65535 || mcpPort === 0)) {
         const tlaMcpServer = new MCPServer(mcpPort);
         context.subscriptions.push(tlaMcpServer);
-
-        // TODO : At this point, we would like to programmatically register the MCP server in Cursor
-        // without creating a permanent file.  A permanent file, i.e., static configuration makes sense for
-        // an external MCP server, but not for the transient MCP server that is started by the extension.
     }
     syncTlcStatisticsSetting()
         .catch((err) => console.error(err))


### PR DESCRIPTION
Enhance MCPServer integration with Cursor by programmatically registering and unregistering the server. Removed outdated comments and improved logging for server registration status.

Related: https://cursor.com/docs/context/mcp-extension-api#conditional-registration

[Feature]