### PR TITLE
Automatically register TLA+ MCP server in VSCode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "name": "TLA+ Community"
     },
     "engines": {
-        "vscode": "^1.95.0"
+        "vscode": "^1.96.0"
     },
     "categories": [
         "Programming Languages",
@@ -40,6 +40,12 @@
     "main": "./out/main.js",
     "browser": "./out/main.browser.js",
     "contributes": {
+        "mcpServerDefinitionProviders": [
+            {
+                "id": "tlaplus.mcp-server",
+                "label": "TLA+ MCP Server"
+            }
+        ],
         "terminal": {
             "profiles": [
                 {
@@ -569,8 +575,8 @@
                 "tlaplus.mcp.port": {
                     "type": "number",
                     "scope": "window",
-                    "default": -1,
-                    "markdownDescription": "Listening port for TLA+ MCP server. If set to -1, MCP server will be disabled. Restart VSCode to apply changes."
+                    "default": 0,
+                    "markdownDescription": "Listening port for TLA+ MCP server. If set to -1, MCP server will be disabled. Set to 0 to have the server listen on a non-deterministically assigned available port. Restart VSCode to apply changes."
                 },
                 "tlaplus.mcp.enableFilesystemTools": {
                     "type": "boolean",

--- a/src/main.ts
+++ b/src/main.ts
@@ -260,13 +260,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // Register coverage commands
     registerCoverageCommands(context, coverageProvider);
 
-    // Start MCP server - unconditionally in Cursor (AI-first IDE), or based on port configuration in VSCode
-    if (vscode.env.appName?.toLowerCase().includes('cursor')) {
-        const p = vscode.workspace.getConfiguration().get<number>('tlaplus.mcp.port');
-        if (typeof p === 'number' && p === -1) {
-            await vscode.workspace.getConfiguration().update('tlaplus.mcp.port', 0, vscode.ConfigurationTarget.Global);
-        }
-    }
     const mcpPort = vscode.workspace.getConfiguration().get<number>('tlaplus.mcp.port');
     if (typeof mcpPort === 'number' && (mcpPort >= 1024 && mcpPort <= 65535 || mcpPort === 0)) {
         const tlaMcpServer = new MCPServer(mcpPort);


### PR DESCRIPTION
- Introduced MCP server definition provider for VS Code.
- Enhanced error logging for MCP server registration.
- Updated MCP server port configuration to allow dynamic port assignment.
- Removed redundant unconditional MCP server start logic for Cursor.

Related:
* https://github.com/tlaplus/vscode-tlaplus/pull/470
* https://code.visualstudio.com/api/extension-guides/ai/mcp#add-mcp-servers-to-vs-code
* https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_add-an-mcp-server
* https://github.com/microsoft/vscode-extension-samples/tree/main/mcp-extension-sample

[Feature]