### PR TITLE
Handle STARTMSG without severity suffix

### DIFF
--- a/src/parsers/tlc.ts
+++ b/src/parsers/tlc.ts
@@ -403,7 +403,7 @@ class ModelCheckResultBuilder {
         }
         const code = parseInt(matches[2]);
         let forcedType;
-        if (matches[3] !== '') {
+        if (matches[3]) {
             const severity = parseInt(matches[3].substring(1));
             if (severity === SEVERITY_ERROR || severity === SEVERITY_TLC_BUG) {
                 forcedType = TlcCodeType.Error;

--- a/tests/suite/parsers/tlc.test.ts
+++ b/tests/suite/parsers/tlc.test.ts
@@ -83,6 +83,49 @@ suite('TLC Output Parser Test Suite', () => {
         );
     });
 
+    test('Parses messages without severity suffix', () => {
+        const fixture = fs.readFileSync(path.join(FIXTURES_PATH, 'print-output.out'), 'utf8');
+        const lines = fixture
+            .split(/\r?\n/)
+            .map(line => line.replace('@!@!@STARTMSG 2193:0 @!@!@', '@!@!@STARTMSG 2193 @!@!@'));
+        return assertOutput(lines, TEST_SPEC_FILES,
+            new CheckResultBuilder('foo', CheckState.Success, CheckStatus.Finished)
+                .setStartDateTime('2019-01-01 01:02:03')
+                .setEndDateTime('2019-01-01 01:02:05')
+                .setDuration(2345)
+                .addInitState('00:00:00', 0, 5184, 5184, 5184)
+                .addOutLine('Foo')
+                .addOutLine('Bar', 2)
+                .addOutLine('Baz')
+                .build()
+        );
+    });
+
+    test('Parses warnings without severity suffix', () => {
+        const warnText = 'Please run the Java VM which executes TLC with a throughput optimized garbage collector'
+            + ' by passing the "-XX:+UseParallelGC" property.';
+        const fixture = fs.readFileSync(path.join(FIXTURES_PATH, 'warning.out'), 'utf8');
+        const lines = fixture
+            .split(/\r?\n/)
+            .map(line => line.replace('@!@!@STARTMSG 2401:3 @!@!@', '@!@!@STARTMSG 2401 @!@!@'));
+        return assertOutput(lines, TEST_SPEC_FILES,
+            new CheckResultBuilder('warning.out', CheckState.Success, CheckStatus.Finished)
+                .addDColFilePath('/Users/bob/example.tla')
+                .setStartDateTime('2019-08-17 00:11:08')
+                .setEndDateTime('2019-08-17 00:11:09')
+                .setDuration(886)
+                .addWarning([message(warnText)])
+                .setProcessInfo(
+                    'Running breadth-first search Model-Checking with fp 22 and seed -5755320172003082571'
+                        + ' with 1 worker on 4 cores with 1820MB heap and 64MB offheap memory [pid: 91333]'
+                        + ' (Mac OS X 10.14.5 x86_64, Amazon.com Inc. 11.0.3 x86_64, MSBDiskFPSet, DiskStateQueue).')
+                .addInitState('00:00:00', 0, 1, 1, 1)
+                .addInitState('00:00:01', 2, 3, 2, 0)
+                .addCoverage('example', 'Init', '/Users/bob/example.tla', range(13, 0, 13, 4), 1, 1)
+                .build()
+        );
+    });
+
     test('Captures warnings', () => {
         return assertOutput('warning.out', TEST_SPEC_FILES,
             new CheckResultBuilder('warning.out', CheckState.Success, CheckStatus.Finished)


### PR DESCRIPTION
- Summary: Handle TLC STARTMSG lines that omit a severity suffix and add parser coverage tests.
- Root cause: The parser assumed the optional severity group was always present and attempted to slice it.
- Fix: Guard severity parsing and add fixture-based tests for messages and warnings without severity suffixes.
- Tests: `MOCHA_GREP="Parses messages without severity suffix|Parses warnings without severity suffix" npm test`
