### PR TITLE
Correct deleted value handling

### DIFF
--- a/src/model/check.ts
+++ b/src/model/check.ts
@@ -167,7 +167,7 @@ export class Value {
     }
 
     setDeleted(): Value {
-        this.changeType = Change.MODIFIED;
+        this.changeType = Change.DELETED;
         return this;
     }
 
@@ -234,6 +234,13 @@ export abstract class CollectionValue extends Value {
                 const subItem = item.findItem(id);
                 if (subItem) {
                     return subItem;
+                }
+            }
+        }
+        if (this.deletedItems) {
+            for (const item of this.deletedItems) {
+                if (item.id === id) {
+                    return item;
                 }
             }
         }

--- a/tests/suite/model/check.test.ts
+++ b/tests/suite/model/check.test.ts
@@ -160,6 +160,11 @@ suite('Check Model Test Suite', () => {
         );
     });
 
+    test('Marks deleted values as deleted', () => {
+        const value = v(1, 'one').setDeleted();
+        assert.equal(value.changeType, Change.DELETED);
+    });
+
     test('Finds subitem by ID', () => {
         Value.switchIdsOn();
         const varOne = v(1, 'one');
@@ -186,6 +191,21 @@ suite('Check Model Test Suite', () => {
                 v(2, 'two')));
         const found = root.findItem(varOne.id);
         assert.equal(typeof found, 'undefined');
+    });
+
+    test('Finds deleted items from deletedItems list', () => {
+        Value.switchIdsOn();
+        const seqValue = seq('foo', v(1, 'one'));
+        seqValue.addDeletedItems([v(2, 'two')]);
+        const root = struct(ROOT,
+            v('bar', 'BAR'),
+            seqValue);
+        const deleted = seqValue.deletedItems ? seqValue.deletedItems[0] : undefined;
+        assert.ok(deleted);
+        const found = root.findItem(deleted!.id);
+        assert.ok(found);
+        assert.equal(found?.id, deleted!.id);
+        assert.equal(found?.changeType, Change.DELETED);
     });
 });
 


### PR DESCRIPTION
- Summary: Correct deleted value change types and resolve deleted items when showing values.
- Root cause: `Value.setDeleted()` set `MODIFIED` and `findItem()` skipped `deletedItems` entirely.
- Fix: Set `DELETED` in `setDeleted()`, search `deletedItems` in `findItem()`, and add regression tests.
- Tests: `MOCHA_GREP="Check Model Test Suite" npm test`
