### PR TITLE
Fix TLC coverage settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,261 @@
                 "react-dom": "^16.3.2 || ^17.0.0 || ^18.0.0"
             }
         },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+            "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+            "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+            "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+            "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+            "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+            "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+            "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+            "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+            "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+            "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+            "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+            "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+            "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+            "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+            "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@esbuild/linux-x64": {
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
@@ -92,6 +347,108 @@
             "optional": true,
             "os": [
                 "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+            "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+            "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+            "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+            "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+            "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.17.19",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+            "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
             ],
             "engines": {
                 "node": ">=12"

--- a/src/commands/toggleCoverage.ts
+++ b/src/commands/toggleCoverage.ts
@@ -16,6 +16,9 @@ export function registerCoverageCommands(
         100
     );
     context.subscriptions.push(statusBarItem);
+    context.subscriptions.push(
+        provider.onDidChangeEnabled((enabled) => updateStatusBar(enabled))
+    );
 
     context.subscriptions.push(
         vscode.commands.registerCommand(CMD_TOGGLE_COVERAGE, () => {

--- a/tests/suite/tlcCoverage.test.ts
+++ b/tests/suite/tlcCoverage.test.ts
@@ -1,0 +1,117 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { TlcCoverageDecorationProvider } from '../../src/tlcCoverage';
+
+suite('TLC Coverage Settings', () => {
+    const enabledKey = 'tlaplus.tlc.profiler.enabled';
+    const thresholdsKey = 'tlaplus.tlc.profiler.thresholds';
+    const config = vscode.workspace.getConfiguration();
+    let originalEnabled: boolean | undefined;
+    let originalThresholds: unknown;
+
+    suiteSetup(() => {
+        originalEnabled = config.inspect<boolean>(enabledKey)?.globalValue;
+        originalThresholds = config.inspect(thresholdsKey)?.globalValue;
+    });
+
+    suiteTeardown(async () => {
+        await config.update(enabledKey, originalEnabled, vscode.ConfigurationTarget.Global);
+        await config.update(thresholdsKey, originalThresholds as unknown, vscode.ConfigurationTarget.Global);
+    });
+
+    function getLevelByName(provider: TlcCoverageDecorationProvider, name: string) {
+        const levels = (provider as unknown as { coverageLevels: Array<{ name: string; minInvocations: number; maxInvocations: number }> })
+            .coverageLevels;
+        const level = levels.find(entry => entry.name === name);
+        assert.ok(level, `Missing coverage level ${name}`);
+        return level!;
+    }
+
+    test('applies enabled setting on construction', async () => {
+        await config.update(enabledKey, true, vscode.ConfigurationTarget.Global);
+        const provider = new TlcCoverageDecorationProvider({} as vscode.ExtensionContext);
+        try {
+            assert.strictEqual(provider.isEnabled(), true);
+        } finally {
+            provider.dispose();
+        }
+    });
+
+    test('uses configured thresholds for absolute coverage levels', async () => {
+        await config.update(
+            thresholdsKey,
+            { rare: 1, low: 2, medium: 3, high: 4 },
+            vscode.ConfigurationTarget.Global
+        );
+        const provider = new TlcCoverageDecorationProvider({} as vscode.ExtensionContext);
+        try {
+            const rare = getLevelByName(provider, 'rare');
+            const low = getLevelByName(provider, 'low');
+            const medium = getLevelByName(provider, 'medium');
+            const high = getLevelByName(provider, 'high');
+            const hot = getLevelByName(provider, 'hot');
+
+            assert.strictEqual(rare.minInvocations, 1);
+            assert.strictEqual(rare.maxInvocations, 1);
+            assert.strictEqual(low.minInvocations, 2);
+            assert.strictEqual(low.maxInvocations, 2);
+            assert.strictEqual(medium.minInvocations, 3);
+            assert.strictEqual(medium.maxInvocations, 3);
+            assert.strictEqual(high.minInvocations, 4);
+            assert.strictEqual(high.maxInvocations, 4);
+            assert.strictEqual(hot.minInvocations, 5);
+        } finally {
+            provider.dispose();
+        }
+    });
+
+    test('falls back to defaults when thresholds are invalid', async () => {
+        await config.update(
+            thresholdsKey,
+            { rare: 10, low: 5, medium: 1000, high: 10000 },
+            vscode.ConfigurationTarget.Global
+        );
+        const provider = new TlcCoverageDecorationProvider({} as vscode.ExtensionContext);
+        try {
+            const rare = getLevelByName(provider, 'rare');
+            const low = getLevelByName(provider, 'low');
+            const medium = getLevelByName(provider, 'medium');
+            const high = getLevelByName(provider, 'high');
+            const hot = getLevelByName(provider, 'hot');
+
+            assert.strictEqual(rare.minInvocations, 1);
+            assert.strictEqual(rare.maxInvocations, 10);
+            assert.strictEqual(low.minInvocations, 11);
+            assert.strictEqual(low.maxInvocations, 100);
+            assert.strictEqual(medium.minInvocations, 101);
+            assert.strictEqual(medium.maxInvocations, 1000);
+            assert.strictEqual(high.minInvocations, 1001);
+            assert.strictEqual(high.maxInvocations, 10000);
+            assert.strictEqual(hot.minInvocations, 10001);
+        } finally {
+            provider.dispose();
+        }
+    });
+
+    test('emits enabled change when configuration updates', async () => {
+        await config.update(enabledKey, false, vscode.ConfigurationTarget.Global);
+        const provider = new TlcCoverageDecorationProvider({} as vscode.ExtensionContext);
+        try {
+            const enabledPromise = new Promise<boolean>((resolve, reject) => {
+                const timeout = setTimeout(() => reject(new Error('Timed out waiting for enabled event')), 2000);
+                const disposable = provider.onDidChangeEnabled(value => {
+                    clearTimeout(timeout);
+                    disposable.dispose();
+                    resolve(value);
+                });
+            });
+
+            await config.update(enabledKey, true, vscode.ConfigurationTarget.Global);
+            const value = await enabledPromise;
+            assert.strictEqual(value, true);
+            assert.strictEqual(provider.isEnabled(), true);
+        } finally {
+            provider.dispose();
+        }
+    });
+});


### PR DESCRIPTION
- Summary: Honor TLC coverage enabled and thresholds settings, plus config-driven status bar updates.
- Root cause: Coverage provider used hard-coded thresholds and never read the enabled setting; status bar didn't react to config changes.
- Fix: Apply config on construction and on change, validate thresholds, emit enablement changes, and add tests.
- Tests: MOCHA_GREP=Coverage npm test
