### PR TITLE
Initial model-editor setup

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -76,6 +76,16 @@ const webviewCoverageConfig = {
     }
 };
 
+/** @type BuildOptions */
+const webviewModelEditorConfig = {
+    ...baseConfig,
+    target: 'es2020',
+    format: 'esm',
+    tsconfig: 'tsconfig.webview.json',
+    entryPoints: ['./src/webview/model-editor.tsx'],
+    outfile: './out/model-editor.js',
+};
+
 const watchPlugin = (name) => [{
     name: 'watch-plugin',
     setup(build) {
@@ -100,6 +110,10 @@ const watchPlugin = (name) => [{
                 ...webviewCoverageConfig,
                 plugins: watchPlugin('webviewCoverageConfig')
             })).watch();
+            (await context({
+                ...webviewModelEditorConfig,
+                plugins: watchPlugin('webviewModelEditorConfig')
+            })).watch();
         } else {
             // Build extension
             await build(extensionConfig);
@@ -107,6 +121,7 @@ const watchPlugin = (name) => [{
             await build(webviewConfig);
             await build(webviewCurrentProofStepConfig);
             await build(webviewCoverageConfig);
+            await build(webviewModelEditorConfig);
             console.log('build complete');
         }
     } catch (err) {

--- a/package.json
+++ b/package.json
@@ -40,16 +40,6 @@
     "main": "./out/main.js",
     "browser": "./out/main.browser.js",
     "contributes": {
-        "customEditors": [
-            {
-                "viewType": "tlaplus.cfgEditor",
-                "displayName": "TLA+ Model Editor",
-                "selector": [
-                    { "filenamePattern": "*.cfg" }
-                ],
-                "priority": "option"
-            }
-        ],
         "mcpServerDefinitionProviders": [
             {
                 "id": "tlaplus.mcp-server",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,16 @@
     "main": "./out/main.js",
     "browser": "./out/main.browser.js",
     "contributes": {
+        "customEditors": [
+            {
+                "viewType": "tlaplus.cfgEditor",
+                "displayName": "TLA+ Model Editor",
+                "selector": [
+                    { "filenamePattern": "*.cfg" }
+                ],
+                "priority": "option"
+            }
+        ],
         "mcpServerDefinitionProviders": [
             {
                 "id": "tlaplus.mcp-server",
@@ -337,6 +347,11 @@
                 "category": "TLA+"
             },
             {
+                "command": "tlaplus.model.editor.display",
+                "title": "Open with Model Editor",
+                "category": "TLA+"
+            },
+            {
                 "command": "tlaplus.out.visualize",
                 "title": "Visualize TLC output",
                 "category": "TLA+"
@@ -436,6 +451,10 @@
                     "when": "editorLangId == tlaplus || editorLangId == tlaplus_cfg"
                 },
                 {
+                    "command": "tlaplus.model.editor.display",
+                    "when": "(editorLangId == tlaplus || editorLangId == tlaplus_cfg) && config.tlaplus.modelEditor.enabled"
+                },
+                {
                     "command": "tlaplus.model.check.runAgain",
                     "when": "tlaplus.tlc.canRunAgain"
                 },
@@ -479,6 +498,11 @@
                     "command": "tlaplus.model.check.run",
                     "when": "resourceLangId == tlaplus || resourceLangId == tlaplus_cfg",
                     "group": "z_commands"
+                },
+                {
+                    "command": "tlaplus.model.editor.display",
+                    "when": "(resourceLangId == tlaplus || resourceLangId == tlaplus_cfg) && config.tlaplus.modelEditor.enabled",
+                    "group": "z_commands"
                 }
             ],
             "editor/context": [
@@ -486,6 +510,11 @@
                     "command": "tlaplus.model.check.run",
                     "when": "editorLangId == tlaplus || editorLangId == tlaplus_cfg",
                     "group": "z_commands@10"
+                },
+                {
+                    "command": "tlaplus.model.editor.display",
+                    "when": "(editorLangId == tlaplus || editorLangId == tlaplus_cfg) && config.tlaplus.modelEditor.enabled",
+                    "group": "z_commands@15"
                 },
                 {
                     "command": "tlaplus.debugger.run",
@@ -508,6 +537,11 @@
                     "command": "tlaplus.debugger.run",
                     "when": "resourceLangId == tlaplus || editorLangId == tlaplus_cfg",
                     "group": "1_run@20"
+                },
+                {
+                    "command": "tlaplus.model.editor.display",
+                    "when": "(resourceLangId == tlaplus || editorLangId == tlaplus_cfg) && config.tlaplus.modelEditor.enabled",
+                    "group": "navigation"
                 },
                 {
                     "command": "tlaplus.tlc.profiler.toggle",
@@ -717,6 +751,11 @@
                         "high": 10000
                     },
                     "description": "Invocation count thresholds for coverage levels"
+                },
+                "tlaplus.modelEditor.enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Enable the visual Model Editor for creating and editing TLC model configurations. This is an experimental feature — [share feedback](https://github.com/tlaplus/vscode-tlaplus/issues)."
                 }
             }
         },

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,6 @@ import { registerCoverageCommands } from './commands/toggleCoverage';
 import { acquireJarFileSystemProvider } from './JarFileSystemProvider';
 import {
     CMD_MODEL_EDITOR_DISPLAY,
-    registerModelEditor,
     showModelEditor
 } from './panels/modelEditorView';
 
@@ -134,7 +133,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.commands.registerCommand(
             CMD_MODEL_EDITOR_DISPLAY,
             (uri?: vscode.Uri) => showModelEditor(context, uri)),
-        registerModelEditor(context),
         vscode.commands.registerCommand(
             CMD_VISUALIZE_TLC_OUTPUT,
             () => visualizeTlcOutput(context)),

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,11 @@ import { MCPServer } from './lm/MCPServer';
 import { TlcCoverageDecorationProvider } from './tlcCoverage';
 import { registerCoverageCommands } from './commands/toggleCoverage';
 import { acquireJarFileSystemProvider } from './JarFileSystemProvider';
+import {
+    CMD_MODEL_EDITOR_DISPLAY,
+    registerModelEditor,
+    showModelEditor
+} from './panels/modelEditorView';
 
 const TLAPLUS_FILE_SELECTOR: vscode.DocumentSelector = { scheme: 'file', language: LANG_TLAPLUS };
 const TLAPLUS_CFG_FILE_SELECTOR: vscode.DocumentSelector = { scheme: 'file', language: LANG_TLAPLUS_CFG };
@@ -126,6 +131,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.commands.registerCommand(
             CMD_CHECK_MODEL_DISPLAY,
             () => displayModelChecking(context)),
+        vscode.commands.registerCommand(
+            CMD_MODEL_EDITOR_DISPLAY,
+            (uri?: vscode.Uri) => showModelEditor(context, uri)),
+        registerModelEditor(context),
         vscode.commands.registerCommand(
             CMD_VISUALIZE_TLC_OUTPUT,
             () => visualizeTlcOutput(context)),

--- a/src/panels/modelEditorView.ts
+++ b/src/panels/modelEditorView.ts
@@ -1,0 +1,142 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { getNonce } from './utilities/getNonce';
+import { getUri } from './utilities/getUri';
+
+export const CMD_MODEL_EDITOR_DISPLAY = 'tlaplus.model.editor.display';
+export const MODEL_EDITOR_VIEW_TYPE = 'tlaplus.cfgEditor';
+const CFG_MODEL_EDITOR_ENABLED = 'tlaplus.modelEditor.enabled';
+const PANEL_VIEW_TYPE = 'tlaplus.modelEditor';
+const PANEL_TITLE = 'TLA+ Model Editor';
+
+function isModelEditorEnabled(): boolean {
+    return vscode.workspace.getConfiguration()
+        .get<boolean>(CFG_MODEL_EDITOR_ENABLED, false);
+}
+
+/**
+ * Entry point for the "Open with Model Editor" command.
+ */
+export function showModelEditor(
+    context: vscode.ExtensionContext,
+    uri?: vscode.Uri
+): void {
+    const fileUri = uri ?? vscode.window.activeTextEditor?.document.uri;
+    if (!fileUri) {
+        void vscode.window.showWarningMessage(
+            'No TLA+ specification file is open.'
+        );
+        return;
+    }
+
+    if (fileUri.fsPath.endsWith('.cfg')) {
+        void vscode.commands.executeCommand(
+            'vscode.openWith', fileUri, MODEL_EDITOR_VIEW_TYPE,
+            vscode.ViewColumn.Beside
+        );
+        return;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+        PANEL_VIEW_TYPE,
+        `${PANEL_TITLE}: ${path.basename(fileUri.fsPath)}`,
+        vscode.ViewColumn.Beside,
+        { enableScripts: true }
+    );
+    configureWebview(panel, context.extensionUri);
+}
+
+/**
+ * CustomTextEditorProvider for .cfg files, enabling
+ * "Reopen Editor With..." → TLA+ Model Editor.
+ *
+ * Only registered while the feature flag is enabled.
+ */
+export class ModelEditorCfgProvider implements vscode.CustomTextEditorProvider {
+
+    constructor(private readonly context: vscode.ExtensionContext) { }
+
+    public resolveCustomTextEditor(
+        _document: vscode.TextDocument,
+        webviewPanel: vscode.WebviewPanel
+    ): void {
+        configureWebview(webviewPanel, this.context.extensionUri);
+    }
+}
+
+/**
+ * Registers the custom editor provider for the Model Editor and keeps
+ * its registration in sync with the `tlaplus.modelEditor.enabled`
+ * setting.
+ */
+export function registerModelEditor(
+    context: vscode.ExtensionContext
+): vscode.Disposable {
+    let registration: vscode.Disposable | undefined;
+
+    const sync = () => {
+        const enabled = isModelEditorEnabled();
+        if (enabled && !registration) {
+            registration = vscode.window.registerCustomEditorProvider(
+                MODEL_EDITOR_VIEW_TYPE,
+                new ModelEditorCfgProvider(context),
+                { supportsMultipleEditorsPerDocument: false }
+            );
+        } else if (!enabled && registration) {
+            registration.dispose();
+            registration = undefined;
+        }
+    };
+
+    sync();
+
+    const configListener = vscode.workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration(CFG_MODEL_EDITOR_ENABLED)) {
+            sync();
+        }
+    });
+
+    return {
+        dispose: () => {
+            configListener.dispose();
+            registration?.dispose();
+            registration = undefined;
+        }
+    };
+}
+
+function configureWebview(
+    panel: vscode.WebviewPanel,
+    extensionUri: vscode.Uri
+): void {
+    panel.webview.options = {
+        enableScripts: true,
+        localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'out')]
+    };
+    panel.webview.html = getWebviewHtml(panel.webview, extensionUri);
+}
+
+function getWebviewHtml(
+    webview: vscode.Webview,
+    extensionUri: vscode.Uri
+): string {
+    const scriptUri = getUri(webview, extensionUri, ['out', 'model-editor.js']);
+    const nonce = getNonce();
+    /* eslint-disable max-len */
+    return /*html*/ `
+        <!DOCTYPE html>
+        <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline' ${webview.cspSource}; script-src 'nonce-${nonce}';">
+                <title>${PANEL_TITLE}</title>
+            </head>
+            <body>
+                <div id="root"></div>
+                <script type="module" nonce="${nonce}" src="${scriptUri}"></script>
+            </body>
+        </html>
+    `;
+    /* eslint-enable max-len */
+}

--- a/src/panels/modelEditorView.ts
+++ b/src/panels/modelEditorView.ts
@@ -4,15 +4,8 @@ import { getNonce } from './utilities/getNonce';
 import { getUri } from './utilities/getUri';
 
 export const CMD_MODEL_EDITOR_DISPLAY = 'tlaplus.model.editor.display';
-export const MODEL_EDITOR_VIEW_TYPE = 'tlaplus.cfgEditor';
-const CFG_MODEL_EDITOR_ENABLED = 'tlaplus.modelEditor.enabled';
 const PANEL_VIEW_TYPE = 'tlaplus.modelEditor';
 const PANEL_TITLE = 'TLA+ Model Editor';
-
-function isModelEditorEnabled(): boolean {
-    return vscode.workspace.getConfiguration()
-        .get<boolean>(CFG_MODEL_EDITOR_ENABLED, false);
-}
 
 /**
  * Entry point for the "Open with Model Editor" command.
@@ -29,14 +22,6 @@ export function showModelEditor(
         return;
     }
 
-    if (fileUri.fsPath.endsWith('.cfg')) {
-        void vscode.commands.executeCommand(
-            'vscode.openWith', fileUri, MODEL_EDITOR_VIEW_TYPE,
-            vscode.ViewColumn.Beside
-        );
-        return;
-    }
-
     const panel = vscode.window.createWebviewPanel(
         PANEL_VIEW_TYPE,
         `${PANEL_TITLE}: ${path.basename(fileUri.fsPath)}`,
@@ -44,65 +29,6 @@ export function showModelEditor(
         { enableScripts: true }
     );
     configureWebview(panel, context.extensionUri);
-}
-
-/**
- * CustomTextEditorProvider for .cfg files, enabling
- * "Reopen Editor With..." → TLA+ Model Editor.
- *
- * Only registered while the feature flag is enabled.
- */
-export class ModelEditorCfgProvider implements vscode.CustomTextEditorProvider {
-
-    constructor(private readonly context: vscode.ExtensionContext) { }
-
-    public resolveCustomTextEditor(
-        _document: vscode.TextDocument,
-        webviewPanel: vscode.WebviewPanel
-    ): void {
-        configureWebview(webviewPanel, this.context.extensionUri);
-    }
-}
-
-/**
- * Registers the custom editor provider for the Model Editor and keeps
- * its registration in sync with the `tlaplus.modelEditor.enabled`
- * setting.
- */
-export function registerModelEditor(
-    context: vscode.ExtensionContext
-): vscode.Disposable {
-    let registration: vscode.Disposable | undefined;
-
-    const sync = () => {
-        const enabled = isModelEditorEnabled();
-        if (enabled && !registration) {
-            registration = vscode.window.registerCustomEditorProvider(
-                MODEL_EDITOR_VIEW_TYPE,
-                new ModelEditorCfgProvider(context),
-                { supportsMultipleEditorsPerDocument: false }
-            );
-        } else if (!enabled && registration) {
-            registration.dispose();
-            registration = undefined;
-        }
-    };
-
-    sync();
-
-    const configListener = vscode.workspace.onDidChangeConfiguration((e) => {
-        if (e.affectsConfiguration(CFG_MODEL_EDITOR_ENABLED)) {
-            sync();
-        }
-    });
-
-    return {
-        dispose: () => {
-            configListener.dispose();
-            registration?.dispose();
-            registration = undefined;
-        }
-    };
 }
 
 function configureWebview(

--- a/src/webview/model-editor.tsx
+++ b/src/webview/model-editor.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { createRoot } from 'react-dom/client';
+
+const containerStyle: React.CSSProperties = {
+    padding: '24px',
+    fontFamily: 'var(--vscode-font-family)',
+    color: 'var(--vscode-foreground)'
+};
+
+const headingStyle: React.CSSProperties = {
+    fontSize: '1.25rem',
+    margin: '0 0 8px 0'
+};
+
+const noteStyle: React.CSSProperties = {
+    color: 'var(--vscode-descriptionForeground)',
+    margin: 0
+};
+
+function ModelEditorApp(): JSX.Element {
+    return (
+        <React.StrictMode>
+            <div style={containerStyle}>
+                <h1 style={headingStyle}>TLA+ Model Editor</h1>
+                <p style={noteStyle}>
+                    The visual model editor is under construction.
+                </p>
+            </div>
+        </React.StrictMode>
+    );
+}
+
+const root = createRoot(document.getElementById('root') as HTMLElement);
+root.render(<ModelEditorApp />);

--- a/tests/suite/panels/modelEditorView.test.ts
+++ b/tests/suite/panels/modelEditorView.test.ts
@@ -5,16 +5,9 @@ import {
     CMD_MODEL_EDITOR_DISPLAY
 } from '../../../src/panels/modelEditorView';
 
-const CFG_KEY = 'tlaplus.modelEditor.enabled';
 const FIXTURE_TLA = path.resolve(
     __dirname, '..', '..', 'fixtures', 'DivergenceTest.tla'
 );
-
-async function setEnabled(value: boolean | undefined): Promise<void> {
-    await vscode.workspace.getConfiguration().update(
-        CFG_KEY, value, vscode.ConfigurationTarget.Global
-    );
-}
 
 function modelEditorTabs(): vscode.Tab[] {
     return vscode.window.tabGroups.all
@@ -38,7 +31,6 @@ suite('Model Editor View Test Suite', () => {
 
     suiteTeardown(async () => {
         await closeModelEditorTabs();
-        await setEnabled(undefined);
     });
 
     test('Command is registered', async () => {
@@ -49,14 +41,12 @@ suite('Model Editor View Test Suite', () => {
         );
     });
 
-    test('Setting enabled: invoking the command opens the model editor', async () => {
-        await setEnabled(true);
+    test('Invoking the command opens the model editor', async () => {
         await closeModelEditorTabs();
 
         await vscode.commands.executeCommand(
             CMD_MODEL_EDITOR_DISPLAY, vscode.Uri.file(FIXTURE_TLA)
         );
-        // Poll for the tab to appear (up to 2s)
         let tabs = modelEditorTabs();
         const deadline = Date.now() + 2000;
         while (tabs.length === 0 && Date.now() < deadline) {
@@ -65,7 +55,8 @@ suite('Model Editor View Test Suite', () => {
         }
         assert.strictEqual(
             tabs.length, 1,
-            'Exactly one model editor tab should be open when enabled'
+            'Exactly one model editor tab should be open'
         );
     });
 });
+

--- a/tests/suite/panels/modelEditorView.test.ts
+++ b/tests/suite/panels/modelEditorView.test.ts
@@ -31,6 +31,11 @@ async function closeModelEditorTabs(): Promise<void> {
 
 suite('Model Editor View Test Suite', () => {
 
+    suiteSetup(async () => {
+        const ext = vscode.extensions.getExtension('tlaplus.vscode-ide');
+        await ext?.activate();
+    });
+
     suiteTeardown(async () => {
         await closeModelEditorTabs();
         await setEnabled(undefined);

--- a/tests/suite/panels/modelEditorView.test.ts
+++ b/tests/suite/panels/modelEditorView.test.ts
@@ -1,0 +1,66 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import {
+    CMD_MODEL_EDITOR_DISPLAY
+} from '../../../src/panels/modelEditorView';
+
+const CFG_KEY = 'tlaplus.modelEditor.enabled';
+const FIXTURE_TLA = path.resolve(
+    __dirname, '..', '..', 'fixtures', 'DivergenceTest.tla'
+);
+
+async function setEnabled(value: boolean | undefined): Promise<void> {
+    await vscode.workspace.getConfiguration().update(
+        CFG_KEY, value, vscode.ConfigurationTarget.Global
+    );
+}
+
+function modelEditorTabs(): vscode.Tab[] {
+    return vscode.window.tabGroups.all
+        .flatMap((g) => g.tabs)
+        .filter((t) => t.label.startsWith('TLA+ Model Editor'));
+}
+
+async function closeModelEditorTabs(): Promise<void> {
+    const tabs = modelEditorTabs();
+    if (tabs.length > 0) {
+        await vscode.window.tabGroups.close(tabs);
+    }
+}
+
+suite('Model Editor View Test Suite', () => {
+
+    suiteTeardown(async () => {
+        await closeModelEditorTabs();
+        await setEnabled(undefined);
+    });
+
+    test('Command is registered', async () => {
+        const commands = await vscode.commands.getCommands(true);
+        assert.ok(
+            commands.includes(CMD_MODEL_EDITOR_DISPLAY),
+            `Expected command ${CMD_MODEL_EDITOR_DISPLAY} to be registered`
+        );
+    });
+
+    test('Setting enabled: invoking the command opens the model editor', async () => {
+        await setEnabled(true);
+        await closeModelEditorTabs();
+
+        await vscode.commands.executeCommand(
+            CMD_MODEL_EDITOR_DISPLAY, vscode.Uri.file(FIXTURE_TLA)
+        );
+        // Poll for the tab to appear (up to 2s)
+        let tabs = modelEditorTabs();
+        const deadline = Date.now() + 2000;
+        while (tabs.length === 0 && Date.now() < deadline) {
+            await new Promise((r) => setTimeout(r, 50));
+            tabs = modelEditorTabs();
+        }
+        assert.strictEqual(
+            tabs.length, 1,
+            'Exactly one model editor tab should be open when enabled'
+        );
+    });
+});


### PR DESCRIPTION
This PR adds the basic wirings for a new webview for the model editor. 

The webview and commands to open it are hidden behind a new setting `config.tlaplus.modelEditor.enabled`, disabled by default.