### PR TITLE
Fix fetch failed on long-running MCP TLC tool calls

### DIFF
--- a/src/lm/MCPServer.ts
+++ b/src/lm/MCPServer.ts
@@ -440,7 +440,13 @@ export class MCPServer implements vscode.Disposable {
             version: '1.0.0',
         }, {
             capabilities: {
-                resources: {}  // Enable resource support
+                resources: {},  // Enable resource support
+                // Enable server-to-client logging notifications. We use these as a
+                // keep-alive on long-running tools (e.g. tlaplus_mcp_tlc_check) so that
+                // the SSE stream stays active and the client (Cursor, Claude Code, ...)
+                // does not abort the underlying fetch with errors like
+                // {"error":"fetch failed"} after ~60s of silence.
+                logging: {}
             }
         });
 
@@ -675,14 +681,14 @@ export class MCPServer implements vscode.Disposable {
                 // eslint-disable-next-line max-len
                 extraJavaOpts: z.array(z.string()).optional().describe('Optional array of additional Java options to pass to the JVM (e.g., ["-Xmx4g", "-Dtlc2.TLC.stopAfter=60"]).')
             },
-            async ({ fileName, cfgFile, extraOpts, extraJavaOpts }) => {
+            async ({ fileName, cfgFile, extraOpts, extraJavaOpts }, extra) => {
                 const absolutePath = this.resolveFilePath(fileName);
                 const validatedPath = this.validateWorkspacePath(absolutePath);
                 const cfgFilePath = cfgFile ? this.validateWorkspacePath(this.resolveFilePath(cfgFile)) : undefined;
                 // Prepend the command line argument ['-modelcheck'] to extra opts.
                 const options = extraOpts ? ['-cleanup', '-modelcheck', ...extraOpts] : ['-cleanup', '-modelcheck'];
                 const javaOpts = extraJavaOpts || [];
-                return this.runTLCInMCP(validatedPath, options, javaOpts, cfgFilePath);
+                return this.runTLCInMCP(validatedPath, options, javaOpts, cfgFilePath, extra);
             }
         );
 
@@ -698,14 +704,14 @@ export class MCPServer implements vscode.Disposable {
                 // eslint-disable-next-line max-len
                 extraJavaOpts: z.array(z.string()).optional().describe('Optional array of additional Java options to pass to the JVM (e.g., ["-Xmx4g"]). Note: -Dtlc2.TLC.stopAfter=3 is set by default.')
             },
-            async ({ fileName, cfgFile, extraOpts, extraJavaOpts }) => {
+            async ({ fileName, cfgFile, extraOpts, extraJavaOpts }, extra) => {
                 const absolutePath = this.resolveFilePath(fileName);
                 const validatedPath = this.validateWorkspacePath(absolutePath);
                 const cfgFilePath = cfgFile ? this.validateWorkspacePath(this.resolveFilePath(cfgFile)) : undefined;
                 // Prepend the command line argument ['-modelcheck'] to extra opts.
                 const options = extraOpts ? ['-cleanup', '-simulate', ...extraOpts] : ['-cleanup', '-simulate'];
                 const javaOpts = ['-Dtlc2.TLC.stopAfter=3', ...(extraJavaOpts || [])];
-                return this.runTLCInMCP(validatedPath, options, javaOpts, cfgFilePath);
+                return this.runTLCInMCP(validatedPath, options, javaOpts, cfgFilePath, extra);
             }
         );
 
@@ -722,7 +728,7 @@ export class MCPServer implements vscode.Disposable {
                 extraJavaOpts: z.array(z.string()).optional().describe('Optional array of additional Java options to pass to the JVM (e.g., ["-Xmx4g"]). Note: -Dtlc2.TLC.stopAfter=3 is set by default.'),
                 behaviorLength: z.number().min(1).describe('The length of the behavior to generate.')
             },
-            async ({ fileName, behaviorLength, cfgFile, extraOpts, extraJavaOpts }) => {
+            async ({ fileName, behaviorLength, cfgFile, extraOpts, extraJavaOpts }, extra) => {
                 const absolutePath = this.resolveFilePath(fileName);
                 const validatedPath = this.validateWorkspacePath(absolutePath);
                 const cfgFilePath = cfgFile ? this.validateWorkspacePath(this.resolveFilePath(cfgFile)) : undefined;
@@ -735,7 +741,8 @@ export class MCPServer implements vscode.Disposable {
                     validatedPath,
                     options,
                     javaOpts,
-                    cfgFilePath
+                    cfgFilePath,
+                    extra
                 );
             }
         );
@@ -753,7 +760,7 @@ export class MCPServer implements vscode.Disposable {
                 // eslint-disable-next-line max-len
                 extraJavaOpts: z.array(z.string()).optional().describe('Optional array of additional Java options to pass to the JVM (e.g., ["-Xmx4g"]).')
             },
-            async ({ fileName, traceFile, cfgFile, extraOpts, extraJavaOpts }) => {
+            async ({ fileName, traceFile, cfgFile, extraOpts, extraJavaOpts }, extra) => {
                 const absolutePath = this.resolveFilePath(fileName);
                 const validatedPath = this.validateWorkspacePath(absolutePath);
 
@@ -792,7 +799,7 @@ export class MCPServer implements vscode.Disposable {
                         ['-cleanup', '-fp', String(fpValue), '-loadtrace', 'tlc', validatedTracePath];
                 }
                 const javaOpts = extraJavaOpts || [];
-                return this.runTLCInMCP(validatedPath, options, javaOpts, cfgFilePath);
+                return this.runTLCInMCP(validatedPath, options, javaOpts, cfgFilePath, extra);
             }
         );
 
@@ -1546,11 +1553,28 @@ export class MCPServer implements vscode.Disposable {
         }
     }
 
+    // TODO: Stream TLC's partial output to the MCP client at runtime.
+    //
+    // Today this method buffers TLC's stdout/stderr into `outputLines` and
+    // only delivers it to the LLM as part of the final tool response (after
+    // `procInfo.process.on('close')` fires). For runaway models that is too
+    // late: by the time TLC finally exits (or the user kills it) the LLM has
+    // no visibility into what went wrong. Diagnosing state-space explosion
+    // in particular requires watching TLC's periodically emitted coverage /
+    // progress lines (states found, distinct, queue size, ...) while TLC is
+    // still running, so the LLM (and the user) can decide to abort early.
+    //
+    // The plumbing is essentially in place: when the client supplied an
+    // `_meta.progressToken`, emit `notifications/progress` events carrying
+    // the lines TLC produced since the last flush; otherwise fall back to
+    // `notifications/message` with level 'info'. Cursor renders progress
+    // events live inside its Tool Execution UI.
     private async runTLCInMCP(
         fileName: string,
         extraOps: string[],
         extraJavaOpts: string[] = [],
-        cfgFilePath?: string
+        cfgFilePath?: string,
+        toolExtra?: TLCToolExtra
     ): Promise<{
         content: { type: 'text'; text: string; }[];
     }> {
@@ -1649,6 +1673,41 @@ export class MCPServer implements vscode.Disposable {
                     console.warn('Error parsing TLC output for webview:', error);
                 });
 
+                // SSE keep-alive (heartbeat).
+                //
+                // MCP clients that talk to us via Streamable HTTP (Cursor, Claude Code, ...)
+                // wrap each tool call in a single fetch() against the SSE response stream.
+                // If the server stays silent for too long (typically ~60s) the client aborts
+                // the underlying socket with errors like {"error":"fetch failed"}, even
+                // though TLC is still happily model checking.
+                //
+                // A periodic notifications/message event is enough activity on the SSE
+                // stream to keep the client's fetch open while TLC runs. We use level
+                // 'debug' so MCP clients do not surface the heartbeat in chat.
+                const HEARTBEAT_INTERVAL_MS = 10_000;
+                const heartbeatStartedAt = Date.now();
+                const heartbeatTimer: NodeJS.Timeout | undefined = toolExtra?.sendNotification
+                    ? setInterval(() => {
+                        const elapsedSec = Math.round((Date.now() - heartbeatStartedAt) / 1000);
+                        try {
+                            const result = toolExtra.sendNotification!({
+                                method: 'notifications/message',
+                                params: {
+                                    level: 'debug',
+                                    logger: 'tlaplus_mcp_tlc',
+                                    data: `keep-alive (TLC running ~${elapsedSec}s)`
+                                }
+                            });
+                            if (result && typeof result.catch === 'function') {
+                                result.catch(err =>
+                                    console.warn('TLA+ MCP keep-alive notification failed:', err));
+                            }
+                        } catch (err) {
+                            console.warn('TLA+ MCP keep-alive notification threw:', err);
+                        }
+                    }, HEARTBEAT_INTERVAL_MS)
+                    : undefined;
+
                 // Also collect text output for the MCP response
                 // Note: Multiple listeners on the same stream work fine in Node.js
                 const stdoutHandler = (data: Buffer) => {
@@ -1669,6 +1728,9 @@ export class MCPServer implements vscode.Disposable {
 
                 // Listen for process completion
                 procInfo.process.on('close', (code) => {
+                    if (heartbeatTimer) {
+                        clearInterval(heartbeatTimer);
+                    }
                     resolve({
                         content: [{
                             type: 'text',
@@ -1687,4 +1749,20 @@ export class MCPServer implements vscode.Disposable {
             };
         }
     }
+}
+
+// Subset of @modelcontextprotocol/sdk's RequestHandlerExtra that we use on the
+// TLC tool path to keep the SSE stream alive during long-running runs. The
+// notification shape mirrors the MCP `notifications/message` schema; we only
+// emit it with `level: 'debug'` so MCP clients (Cursor, Claude Code, ...) do
+// not surface the heartbeat in chat.
+interface TLCToolExtra {
+    sendNotification?: (notification: {
+        method: 'notifications/message';
+        params: {
+            level: 'debug' | 'info' | 'notice' | 'warning' | 'error' | 'critical' | 'alert' | 'emergency';
+            logger?: string;
+            data: unknown;
+        };
+    }) => Promise<void> | void;
 }

--- a/tests/suite/commands/checkModelCancel.test.ts
+++ b/tests/suite/commands/checkModelCancel.test.ts
@@ -1,8 +1,11 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
 suite('CheckModel cancellation handling', () => {
+    const fsp = fs.promises;
     const tla2toolsPath = require.resolve(path.resolve(__dirname, '../../../src/tla2tools'));
     const checkModelPath = require.resolve(path.resolve(__dirname, '../../../src/commands/checkModel'));
     const modelPath = require.resolve(path.resolve(__dirname, '../../../src/model/check'));
@@ -71,12 +74,21 @@ suite('CheckModel cancellation handling', () => {
         const { doCheckModel, CTX_TLC_CAN_RUN_AGAIN, CTX_TLC_RUNNING } = await import(checkModelPath);
         const { SpecFiles } = await import(modelPath);
 
-        const specFiles = new SpecFiles('Dummy.tla', 'Dummy.cfg');
+        const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'check-model-cancel-'));
+        const tlaFile = path.join(tmpDir, 'Dummy.tla');
+        const cfgFile = path.join(tmpDir, 'Dummy.cfg');
+        await fsp.writeFile(tlaFile, '---- MODULE Dummy ----\n====\n');
+        await fsp.writeFile(cfgFile, 'SPECIFICATION Spec\n');
+
+        const specFiles = new SpecFiles(tlaFile, cfgFile);
         const diagnostics = vscode.languages.createDiagnosticCollection('cancel-test');
 
-        await doCheckModel(specFiles, true, {} as vscode.ExtensionContext, diagnostics, true);
-
-        diagnostics.dispose();
+        try {
+            await doCheckModel(specFiles, true, {} as vscode.ExtensionContext, diagnostics, true);
+        } finally {
+            diagnostics.dispose();
+            await fsp.rm(tmpDir, { recursive: true, force: true });
+        }
 
         assert.strictEqual(
             contextValues[CTX_TLC_RUNNING],

--- a/tests/suite/lm/mcpServer.test.ts
+++ b/tests/suite/lm/mcpServer.test.ts
@@ -3,11 +3,39 @@ import * as fs from 'fs';
 import * as http from 'http';
 import * as os from 'os';
 import * as path from 'path';
+import { ChildProcess } from 'child_process';
+import { EventEmitter } from 'events';
 import * as vscode from 'vscode';
 import { MCPServer } from '../../../src/lm/MCPServer';
 import { McpServer as SdkMcpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as checkModel from '../../../src/commands/checkModel';
+import * as common from '../../../src/common';
+import * as tla2tools from '../../../src/tla2tools';
+import { ToolProcessInfo } from '../../../src/tla2tools';
+import { SpecFiles } from '../../../src/model/check';
 
 const fsp = fs.promises;
+
+class MockStdout extends EventEmitter {
+    public on(event: string | symbol, listener: (...args: unknown[]) => void): this {
+        return super.on(event, listener);
+    }
+}
+
+class MockProcess extends EventEmitter {
+    public stdout = new MockStdout();
+    public stderr = new MockStdout();
+    public killed = false;
+    public exitCode: number | null = null;
+    public signalCode: NodeJS.Signals | null = null;
+    public pid = 99999;
+
+    kill(signal?: NodeJS.Signals | number): boolean {
+        this.killed = true;
+        this.emit('killed', signal);
+        return true;
+    }
+}
 
 suite('MCP Server regressions', () => {
     suite('validateArticleName should prevent path traversal', () => {
@@ -384,6 +412,186 @@ suite('MCP Server regressions', () => {
                 text.includes('nonexistent.cfg'),
                 `Error should mention the config file path, got: ${text}`
             );
+        });
+    });
+
+    // Long-running TLC runs invoked through the MCP server (e.g.
+    // `tlaplus_mcp_tlc_check` on a non-trivial spec) failed in Cursor with
+    // `{"error":"fetch failed"}` after roughly a minute. MCP clients using
+    // Streamable HTTP wrap each tool call in a single fetch() against the
+    // SSE response stream; if the server stays silent for too long the
+    // client aborts the underlying socket even though TLC is still
+    // model checking. The fix is a periodic notifications/message ping on
+    // the SSE stream, which is enough activity to keep the client's fetch
+    // open. This suite pins down both halves of that contract: the timer
+    // must actually fire while TLC is running, and it must be cleared
+    // once the run finishes so we do not keep pinging a closed stream.
+    suite('runTLCInMCP heartbeat keeps the MCP SSE stream alive', () => {
+        type Notification = {
+            method: string;
+            params: { data?: unknown; level?: string; logger?: string };
+        };
+
+        const getPrototype = () => MCPServer.prototype as unknown as {
+            runTLCInMCP(
+                fileName: string,
+                extraOps: string[],
+                extraJavaOpts: string[],
+                cfgFilePath?: string,
+                toolExtra?: { sendNotification?: (n: Notification) => void | Promise<void> }
+            ): Promise<{ content: { type: 'text'; text: string }[] }>;
+        };
+
+        type CheckModelMutable = {
+            getSpecFiles: typeof checkModel.getSpecFiles;
+            mapTlcOutputLine: typeof checkModel.mapTlcOutputLine;
+            outChannel: typeof checkModel.outChannel;
+        };
+        type CommonMutable = { exists: typeof common.exists };
+        type Tla2ToolsMutable = { runTlc: typeof tla2tools.runTlc };
+
+        let originals: {
+            getSpecFiles: typeof checkModel.getSpecFiles;
+            mapTlcOutputLine: typeof checkModel.mapTlcOutputLine;
+            bindTo: typeof checkModel.outChannel.bindTo;
+            exists: typeof common.exists;
+            runTlc: typeof tla2tools.runTlc;
+        };
+        let mockProcess: MockProcess;
+        let runTlcCalls: number;
+
+        setup(() => {
+            const checkModelMutable = checkModel as unknown as CheckModelMutable;
+            const commonMutable = common as unknown as CommonMutable;
+            const tla2toolsMutable = tla2tools as unknown as Tla2ToolsMutable;
+
+            originals = {
+                getSpecFiles: checkModelMutable.getSpecFiles,
+                mapTlcOutputLine: checkModelMutable.mapTlcOutputLine,
+                bindTo: checkModelMutable.outChannel.bindTo,
+                exists: commonMutable.exists,
+                runTlc: tla2toolsMutable.runTlc
+            };
+
+            runTlcCalls = 0;
+            mockProcess = new MockProcess();
+
+            const specFiles = new SpecFiles(
+                path.join(os.tmpdir(), 'HeartbeatExample.tla'),
+                path.join(os.tmpdir(), 'HeartbeatExample.cfg')
+            );
+
+            checkModelMutable.getSpecFiles = async () => specFiles;
+            checkModelMutable.mapTlcOutputLine = (line: string) => line.trim();
+            checkModelMutable.outChannel.bindTo = () => { /* no-op */ };
+            commonMutable.exists = async () => true;
+            tla2toolsMutable.runTlc = async () => {
+                runTlcCalls++;
+                return new ToolProcessInfo('tlc', mockProcess as unknown as ChildProcess);
+            };
+        });
+
+        teardown(() => {
+            const checkModelMutable = checkModel as unknown as CheckModelMutable;
+            const commonMutable = common as unknown as CommonMutable;
+            const tla2toolsMutable = tla2tools as unknown as Tla2ToolsMutable;
+
+            checkModelMutable.getSpecFiles = originals.getSpecFiles;
+            checkModelMutable.mapTlcOutputLine = originals.mapTlcOutputLine;
+            checkModelMutable.outChannel.bindTo = originals.bindTo;
+            commonMutable.exists = originals.exists;
+            tla2toolsMutable.runTlc = originals.runTlc;
+
+            // Avoid leaking the parser awaiting a never-ending stream if a
+            // test bailed out before emitting 'close'.
+            if (mockProcess && mockProcess.listenerCount('close') > 0) {
+                mockProcess.emit('close', 0);
+            }
+        });
+
+        test('heartbeat fires repeatedly while TLC runs and stops once it ends', async function() {
+            this.timeout(5000);
+
+            const notifications: Notification[] = [];
+            const sendNotification = (n: Notification) => {
+                notifications.push(n);
+            };
+
+            // The production heartbeat interval is 10s. We only compress that
+            // exact value so test code (mocha's own timeout, our wait loops,
+            // ...) keeps using real wall-clock delays.
+            const realSetInterval = global.setInterval;
+            const HEARTBEAT_INTERVAL_MS = 10_000;
+            const compressInterval = ((
+                cb: (...args: unknown[]) => void,
+                ms?: number,
+                ...args: unknown[]
+            ) => {
+                const compressed = ms === HEARTBEAT_INTERVAL_MS ? 5 : ms;
+                return realSetInterval(cb, compressed as number, ...args);
+            }) as unknown as typeof setInterval;
+
+            const heartbeatPings = () => notifications.filter(n =>
+                n.method === 'notifications/message');
+
+            global.setInterval = compressInterval;
+            try {
+                const tlaFile = path.join(os.tmpdir(), 'HeartbeatExample.tla');
+
+                const runPromise = getPrototype().runTLCInMCP.call(
+                    {},
+                    tlaFile,
+                    ['-cleanup', '-modelcheck'],
+                    [],
+                    undefined,
+                    { sendNotification }
+                );
+
+                const deadline = Date.now() + 2000;
+                while (heartbeatPings().length < 2 && Date.now() < deadline) {
+                    await new Promise(resolve => setTimeout(resolve, 5));
+                }
+
+                const pingsWhileRunning = heartbeatPings().length;
+                assert.ok(
+                    pingsWhileRunning >= 2,
+                    'Expected the heartbeat to fire repeatedly while TLC '
+                        + `is running; saw ${pingsWhileRunning} ping(s). Without a `
+                        + 'heartbeat MCP clients (e.g. Cursor) abort long-running '
+                        + 'TLC tool calls with {"error":"fetch failed"}.'
+                );
+
+                for (const ping of heartbeatPings()) {
+                    assert.strictEqual(
+                        ping.method, 'notifications/message',
+                        'Heartbeat must use notifications/message so it counts as '
+                            + 'SSE traffic for MCP clients');
+                    assert.strictEqual(
+                        ping.params.level, 'debug',
+                        'Heartbeat must use level=debug so MCP clients hide it from chat');
+                    assert.strictEqual(
+                        ping.params.logger, 'tlaplus_mcp_tlc',
+                        'Heartbeat must be tagged with the TLC logger name');
+                }
+
+                // Close the process so runTLCInMCP resolves and clears the timer.
+                mockProcess.emit('close', 0);
+                await runPromise;
+                const pingsAtClose = heartbeatPings().length;
+
+                // If the timer leaked past 'close' we would keep pinging a
+                // client that is no longer listening on the SSE stream.
+                await new Promise(resolve => setTimeout(resolve, 80));
+                assert.strictEqual(
+                    heartbeatPings().length, pingsAtClose,
+                    'Heartbeat timer must be cleared once the TLC run ends; '
+                        + 'a leaked timer would keep pinging a closed SSE stream'
+                );
+
+                assert.strictEqual(runTlcCalls, 1, 'TLC should have been started exactly once');
+            } finally {
+                global.setInterval = realSetInterval;
+            }
         });
     });
 });


### PR DESCRIPTION
Long-running TLC runs invoked through the MCP server (e.g. `tlaplus_mcp_tlc_check` on a non-trivial spec) would fail in Cursor with `{"error":"fetch failed"}` after roughly a minute, and a TLC process orphaned by a cancelled tool call would keep running on the side until it finished on its own.