### PR TITLE
Fix flaky tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,17 +46,15 @@ jobs:
       if: matrix.os == 'windows-latest'
       shell: pwsh
       run: |
-        $miktexBin = 'C:\Program Files\MiKTeX\miktex\bin\x64'
-        if (-not (Get-Command pdflatex -ErrorAction SilentlyContinue)) {
-          choco install miktex --yes
-          Add-Content -Path $env:GITHUB_PATH -Value $miktexBin
-          $env:Path = "$miktexBin;$env:Path"
+        # choco install miktex hits flaky CTAN mirrors; retry a few times.
+        $bin = 'C:\Program Files\MiKTeX\miktex\bin\x64'
+        for ($i = 1; $i -le 5; $i++) {
+          try { choco install miktex --yes --no-progress } catch {}
+          if (Test-Path "$bin\pdflatex.exe") { break }
+          Start-Sleep -Seconds ($i * 10)
         }
-        if (Test-Path "$miktexBin\pdflatex.exe") {
-          & "$miktexBin\pdflatex.exe" --version
-        } else {
-          pdflatex --version
-        }
+        Add-Content $env:GITHUB_PATH $bin
+        & "$bin\pdflatex.exe" --version
     - name: Build
       run: |
         npm run vscode:prepublish

--- a/tests/suite/commands/checkModelCancel.test.ts
+++ b/tests/suite/commands/checkModelCancel.test.ts
@@ -3,23 +3,26 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { SanyData } from '../../../src/parsers/sany';
 
 suite('CheckModel cancellation handling', () => {
     const fsp = fs.promises;
     const tla2toolsPath = require.resolve(path.resolve(__dirname, '../../../src/tla2tools'));
+    const parseModulePath = require.resolve(path.resolve(__dirname, '../../../src/commands/parseModule'));
     const checkModelPath = require.resolve(path.resolve(__dirname, '../../../src/commands/checkModel'));
     const modelPath = require.resolve(path.resolve(__dirname, '../../../src/model/check'));
 
     let originalTla2tools: typeof import('../../../src/tla2tools') | undefined;
+    let originalParseModule: typeof import('../../../src/commands/parseModule') | undefined;
     let originalExecuteCommand: typeof vscode.commands.executeCommand | undefined;
 
-    const makeCacheEntry = (exports: unknown): NodeJS.Module => ({
-        id: tla2toolsPath,
-        filename: tla2toolsPath,
+    const makeCacheEntry = (filename: string, exports: unknown): NodeJS.Module => ({
+        id: filename,
+        filename,
         loaded: true,
         exports,
         parent: null,
-        path: tla2toolsPath,
+        path: filename,
         paths: [],
         children: [],
         require,
@@ -27,21 +30,25 @@ suite('CheckModel cancellation handling', () => {
     } as unknown as NodeJS.Module);
 
     setup(() => {
-        // Ensure a clean slate for module cache
         delete require.cache[checkModelPath];
         delete require.cache[tla2toolsPath];
+        delete require.cache[parseModulePath];
     });
 
     teardown(() => {
-        // Restore executeCommand and cached modules
         if (originalExecuteCommand) {
             (vscode.commands as unknown as { executeCommand: typeof vscode.commands.executeCommand })
                 .executeCommand = originalExecuteCommand;
         }
         if (originalTla2tools) {
-            require.cache[tla2toolsPath] = makeCacheEntry(originalTla2tools);
+            require.cache[tla2toolsPath] = makeCacheEntry(tla2toolsPath, originalTla2tools);
         } else {
             delete require.cache[tla2toolsPath];
+        }
+        if (originalParseModule) {
+            require.cache[parseModulePath] = makeCacheEntry(parseModulePath, originalParseModule);
+        } else {
+            delete require.cache[parseModulePath];
         }
         delete require.cache[checkModelPath];
     });
@@ -49,15 +56,22 @@ suite('CheckModel cancellation handling', () => {
     test('does not leave TLC running context when launch is cancelled', async function() {
         this.timeout(5000);
         originalTla2tools = await import(tla2toolsPath);
+        originalParseModule = await import(parseModulePath);
 
-        // Stub runTlc to simulate user cancelling the options prompt
         const stubbedTla2tools = {
             ...originalTla2tools,
             runTlc: async () => undefined,
         } as typeof import('../../../src/tla2tools');
-        require.cache[tla2toolsPath] = makeCacheEntry(stubbedTla2tools);
+        require.cache[tla2toolsPath] = makeCacheEntry(tla2toolsPath, stubbedTla2tools);
 
-        // Capture context updates
+        // Stub parseSpec to avoid spawning Java SANY, which can exceed the
+        // 5s timeout during cold JVM startup on Windows CI runners.
+        const stubbedParseModule = {
+            ...originalParseModule,
+            parseSpec: async () => new SanyData(),
+        } as typeof import('../../../src/commands/parseModule');
+        require.cache[parseModulePath] = makeCacheEntry(parseModulePath, stubbedParseModule);
+
         const contextValues: Record<string, unknown> = {};
         originalExecuteCommand = vscode.commands.executeCommand;
         const stubExecuteCommand: typeof vscode.commands.executeCommand =

--- a/tests/suite/commands/divergence.test.ts
+++ b/tests/suite/commands/divergence.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../src/parsers/sany';
 
 const FIXTURES_DIR = path.join(__dirname, '..', '..', '..', '..', 'tests', 'fixtures');
+const TEST_TIMEOUT_MS = 5 * 60 * 1000;
 
 suite('PlusCal Divergence Detection Integration Tests', () => {
     let tempDir: string;
@@ -23,7 +24,7 @@ suite('PlusCal Divergence Detection Integration Tests', () => {
     });
 
     test('SANY detects no divergence on clean file with matching checksums', async function () {
-        this.timeout(15000);
+        this.timeout(TEST_TIMEOUT_MS);
         const filePath = copyFixture('DivergenceTest.tla');
         const output = await runSanyOnFile(filePath);
         assert.ok(output.includes('Semantic processing of module DivergenceTest'),
@@ -34,7 +35,7 @@ suite('PlusCal Divergence Detection Integration Tests', () => {
     });
 
     test('SANY detects TLA+ translation divergence when translation is modified', async function () {
-        this.timeout(15000);
+        this.timeout(TEST_TIMEOUT_MS);
         const filePath = copyFixture('DivergenceTest.tla');
 
         let content = fs.readFileSync(filePath, 'utf-8');
@@ -47,7 +48,7 @@ suite('PlusCal Divergence Detection Integration Tests', () => {
     });
 
     test('SANY detects PlusCal divergence when algorithm is modified', async function () {
-        this.timeout(15000);
+        this.timeout(TEST_TIMEOUT_MS);
         const filePath = copyFixture('DivergenceTest.tla');
 
         let content = fs.readFileSync(filePath, 'utf-8');
@@ -60,7 +61,7 @@ suite('PlusCal Divergence Detection Integration Tests', () => {
     });
 
     test('SANY detects both divergences when algorithm and translation are modified', async function () {
-        this.timeout(15000);
+        this.timeout(TEST_TIMEOUT_MS);
         const filePath = copyFixture('DivergenceTest.tla');
 
         let content = fs.readFileSync(filePath, 'utf-8');
@@ -74,7 +75,7 @@ suite('PlusCal Divergence Detection Integration Tests', () => {
     });
 
     test('Pre-model-check: divergence detected on modified TLA+ translation', async function () {
-        this.timeout(15000);
+        this.timeout(TEST_TIMEOUT_MS);
         const filePath = copyFixture('DivergenceTest.tla');
 
         let content = fs.readFileSync(filePath, 'utf-8');
@@ -90,7 +91,7 @@ suite('PlusCal Divergence Detection Integration Tests', () => {
     });
 
     test('Pre-model-check: no divergence on clean file', async function () {
-        this.timeout(15000);
+        this.timeout(TEST_TIMEOUT_MS);
         const filePath = copyFixture('DivergenceTest.tla');
         const content = fs.readFileSync(filePath, 'utf-8');
 
@@ -103,7 +104,7 @@ suite('PlusCal Divergence Detection Integration Tests', () => {
     });
 
     test('Pre-model-check: skipped when no checksums', async function () {
-        this.timeout(15000);
+        this.timeout(TEST_TIMEOUT_MS);
         const filePath = copyFixture('DivergenceTest.tla');
 
         // Remove checksums from the BEGIN TRANSLATION line
@@ -119,7 +120,7 @@ suite('PlusCal Divergence Detection Integration Tests', () => {
     });
 
     test('SANY detects divergence in an imported module', async function () {
-        this.timeout(15000);
+        this.timeout(TEST_TIMEOUT_MS);
         // Copy the fixture as an imported module and break its TLA+ translation.
         const helperPath = path.join(tempDir, 'DivHelper.tla');
         let helperContent = fs.readFileSync(path.join(FIXTURES_DIR, 'DivergenceTest.tla'), 'utf-8');
@@ -159,19 +160,12 @@ suite('PlusCal Divergence Detection Integration Tests', () => {
             capturedOutput += chunk.toString();
         });
 
-        await new Promise<void>((resolve, reject) => {
+        await new Promise<void>((resolve) => {
             if (procInfo.mergedOutput.readableEnded) {
                 resolve();
                 return;
             }
-            const timer = setTimeout(
-                () => reject(new Error('SANY did not finish in time')),
-                10000
-            );
-            procInfo.mergedOutput.once('end', () => {
-                clearTimeout(timer);
-                resolve();
-            });
+            procInfo.mergedOutput.once('end', resolve);
         });
 
         return capturedOutput;


### PR DESCRIPTION
ref: https://github.com/tlaplus/vscode-tlaplus/pull/518#issuecomment-4393454238
I'll run CI a few times and fix any flakiness that comes in the way.

* Add retries for pdflatex installs on windows - sometimes the upstream goes into timeout. Apparently there is no native retry support.
* checkModelCancel was not stubbing parseSpec, causing timeout errors at times when sany was to slow to spawn and finish run.
* the initial sany load in divergence test is quite slow reaching the timeout. Next load takes 3s, and 300ms thereafter. Increased the timeout. This is just an hypothesis, I'm geniunly surprised it takes >15s to finish run that test.

